### PR TITLE
Feat: input, header, button 주요 컴포넌트 분리

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "global-require": 0,
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "jsx-a11y/click-events-have-key-events": "off",
-    "jsx-a11y/no-static-element-interactions": "off"
+    "jsx-a11y/no-static-element-interactions": "off",
+    "react/require-default-props": "off"
   }
 }

--- a/src/app/_component/Button.tsx
+++ b/src/app/_component/Button.tsx
@@ -1,0 +1,33 @@
+interface Props {
+  text: string;
+  styleClass?: string;
+  onClickFn?: () => void;
+  disabled?: boolean;
+  theme?: string;
+}
+
+const themes: { [key: string]: string } = {
+  wide: "w-full h-[56px] disabled:bg-grey-3 hover:bg-[#bb1e4a] bg-pink disabled:text-grey-4 text-white font-bold rounded-xl",
+  md: "p-[8px]",
+};
+
+const Button = ({
+  text,
+  styleClass,
+  onClickFn,
+  disabled = false,
+  theme = "",
+}: Props) => {
+  return (
+    <button
+      type="button"
+      className={`${themes[theme]} ${styleClass}`}
+      disabled={disabled}
+      onClick={onClickFn}
+    >
+      {text}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/app/_component/DefaultHeader.tsx
+++ b/src/app/_component/DefaultHeader.tsx
@@ -7,7 +7,7 @@ interface Props {
   theme?: string;
 }
 
-const SigninHeader = ({
+const DefaultHeader = ({
   text,
   subText = "",
   redirectUrl,
@@ -39,4 +39,4 @@ const SigninHeader = ({
   );
 };
 
-export default SigninHeader;
+export default DefaultHeader;

--- a/src/app/_component/DefaultHeader.tsx
+++ b/src/app/_component/DefaultHeader.tsx
@@ -14,7 +14,7 @@ const DefaultHeader = ({
   theme = "default",
 }: Props) => {
   return (
-    <div className="flex relative h-[48px]">
+    <div className="flex relative w-full h-[48px]">
       {redirectUrl && (
         <Link
           href={redirectUrl}

--- a/src/app/email-signin/_component/EmailSigninForm.tsx
+++ b/src/app/email-signin/_component/EmailSigninForm.tsx
@@ -2,15 +2,13 @@
 
 import useInput from "@/hooks/useInput";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import SigninInput from "./SigninInput";
 import TermsForm from "./TermsForm";
 
 const EmailSigninForm = () => {
   const router = useRouter();
-
-  const [emailFocus, setEmailFocus] = useState(false);
-  const [passwordFocus, setPasswordFocus] = useState(false);
 
   const [termsForm, setTermsForm] = useState(false);
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
@@ -19,22 +17,8 @@ const EmailSigninForm = () => {
     setPortalElement(document.getElementById("portal"));
   }, [termsForm]);
 
-  const emailInputRef = useRef<HTMLInputElement | null>(null);
-  const passwordInputRef = useRef<HTMLInputElement | null>(null);
-
   const emailInput = useInput("");
   const passwordInput = useInput("");
-
-  const handleEmaildleFocus = () => {
-    if (emailInputRef.current) {
-      emailInputRef.current.focus();
-    }
-  };
-  const handlePasswordFocus = () => {
-    if (passwordInputRef.current) {
-      passwordInputRef.current.focus();
-    }
-  };
 
   const openTermsForm = () => {
     setTermsForm(true);
@@ -47,61 +31,19 @@ const EmailSigninForm = () => {
         e.preventDefault();
       }}
     >
-      <div className="relative flex flex-col w-[90%] mb-12">
-        <div
-          className={`absolute ${emailFocus ? "-top-2" : "top-1/2"} ${
-            emailFocus ? "left-0" : "left-[16px]"
-          } -translate-y-1/2 ${
-            emailFocus ? "text-black-2" : "text-grey-4"
-          } duration-500 ${emailFocus ? "text-[13px]" : "text-[16px]"}`}
-          onClick={handleEmaildleFocus}
-        >
-          아이디 또는 이메일
-        </div>
-        <input
-          className="h-[50px] bg-grey-1 outline-none border-none rounded-lg pl-[16px] caret-blue"
-          type="text"
-          name="signin-email"
-          id="signin-email"
-          value={emailInput.value}
-          onChange={emailInput.onChange}
-          ref={emailInputRef}
-          onFocus={() => {
-            setEmailFocus(true);
-          }}
-          onBlur={() => {
-            if (emailInput.value === "") setEmailFocus(false);
-          }}
-        />
-      </div>
-      <div className="relative flex flex-col w-[90%]">
-        <div
-          className={`absolute ${passwordFocus ? "-top-2" : "top-1/2"} ${
-            passwordFocus ? "left-0" : "left-[16px]"
-          } -translate-y-1/2 ${
-            passwordFocus ? "text-black-2" : "text-grey-4"
-          } duration-500 ${passwordFocus ? "text-[13px]" : "text-[16px]"}`}
-          onClick={handlePasswordFocus}
-        >
-          비밀번호
-        </div>
-        <input
-          className="h-[50px] bg-grey-1 outline-none border-none rounded-lg pl-[16px] caret-blue"
-          type="password"
-          name="signin-password"
-          id="signin-password"
-          value={passwordInput.value}
-          ref={passwordInputRef}
-          autoComplete="on"
-          onChange={passwordInput.onChange}
-          onFocus={() => {
-            setPasswordFocus(true);
-          }}
-          onBlur={() => {
-            if (passwordInput.value === "") setPasswordFocus(false);
-          }}
-        />
-      </div>
+      <SigninInput
+        title="아이디 또는 이메일"
+        type="text"
+        name="signin-email"
+        id="signin-email"
+      />
+      <SigninInput
+        title="비밀번호"
+        type="password"
+        name="signin-password"
+        id="signin-password"
+      />
+
       <div className="w-[90%] grow flex items-end">
         <button
           type="button"

--- a/src/app/email-signin/_component/EmailSigninForm.tsx
+++ b/src/app/email-signin/_component/EmailSigninForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import useInput from "@/hooks/useInput";
+import Button from "@/app/_component/Button";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
@@ -17,8 +17,15 @@ const EmailSigninForm = () => {
     setPortalElement(document.getElementById("portal"));
   }, [termsForm]);
 
-  const emailInput = useInput("");
-  const passwordInput = useInput("");
+  const [emailValue, setEmailValue] = useState("");
+  const [passwordValue, setPasswordValue] = useState("");
+
+  const handleEmailInputChange = (inputValue: string) => {
+    setEmailValue(inputValue);
+  };
+  const handlePasswordInputChange = (inputValue: string) => {
+    setPasswordValue(inputValue);
+  };
 
   const openTermsForm = () => {
     setTermsForm(true);
@@ -36,41 +43,33 @@ const EmailSigninForm = () => {
         type="text"
         name="signin-email"
         id="signin-email"
+        onInputChange={handleEmailInputChange}
       />
       <SigninInput
         title="비밀번호"
         type="password"
         name="signin-password"
         id="signin-password"
+        onInputChange={handlePasswordInputChange}
       />
 
       <div className="w-[90%] grow flex items-end">
-        <button
-          type="button"
-          className="w-full h-[56px] disabled:bg-grey-3 hover:bg-[#bb1e4a] bg-pink disabled:text-grey-4 text-white font-bold rounded-xl"
-          disabled={emailInput.value === "" || passwordInput.value === ""}
-        >
-          로그인
-        </button>
+        <Button
+          text="로그인"
+          disabled={emailValue === "" || passwordValue === ""}
+          theme="wide"
+        />
       </div>
       <div className="flex mb-20 mt-2 items-center text-[13px] text-black-4 font-[400]">
-        <button
-          type="button"
-          className="p-[8px] ml-[8px] cursor-pointer"
-          onClick={() => {
+        <Button
+          text="비밀번호 재설정"
+          theme="md"
+          onClickFn={() => {
             router.push("/signin");
           }}
-        >
-          비밀번호 재설정
-        </button>
-        <span className="w-[1px] h-[22px] bg-grey-3 m-[8px]" />
-        <button
-          type="button"
-          className="p-[8px] mr-[8px] cursor-pointer"
-          onClick={openTermsForm}
-        >
-          이메일로 회원가입
-        </button>
+        />
+        <span className="w-[1px] h-[22px] bg-grey-3 my-[8px] mx-[16px]" />
+        <Button text="이메일로 회원가입" theme="md" onClickFn={openTermsForm} />
       </div>
       {termsForm && portalElement
         ? createPortal(<TermsForm setTermsForm={setTermsForm} />, portalElement)

--- a/src/app/email-signin/_component/SigninInput.tsx
+++ b/src/app/email-signin/_component/SigninInput.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import useInput from "@/hooks/useInput";
+import { useRef, useState } from "react";
+
+interface Props {
+  title: string;
+  type: string;
+  name: string;
+  id: string;
+}
+
+const SigninInput = ({ title, type, name, id }: Props) => {
+  const [focus, setFocus] = useState(false);
+  const input = useInput("");
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFocus = () => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  };
+
+  return (
+    <div className="relative flex flex-col w-[90%] mb-12">
+      <div
+        className={`absolute ${focus ? "-top-2" : "top-1/2"} ${
+          focus ? "left-0" : "left-[16px]"
+        } -translate-y-1/2 ${
+          focus ? "text-black-2" : "text-grey-4"
+        } duration-500 ${focus ? "text-[13px]" : "text-[16px]"}`}
+        onClick={handleFocus}
+      >
+        {title}
+      </div>
+      <input
+        className="h-[50px] bg-grey-1 outline-none border-none rounded-lg pl-[16px] caret-blue"
+        type={type}
+        name={name}
+        id={id}
+        value={input.value}
+        onChange={input.onChange}
+        ref={inputRef}
+        onFocus={() => {
+          setFocus(true);
+        }}
+        onBlur={() => {
+          if (input.value === "") setFocus(false);
+        }}
+      />
+    </div>
+  );
+};
+
+export default SigninInput;

--- a/src/app/email-signin/_component/SigninInput.tsx
+++ b/src/app/email-signin/_component/SigninInput.tsx
@@ -8,9 +8,10 @@ interface Props {
   type: string;
   name: string;
   id: string;
+  onInputChange?: (value: string) => void;
 }
 
-const SigninInput = ({ title, type, name, id }: Props) => {
+const SigninInput = ({ title, type, name, id, onInputChange }: Props) => {
   const [focus, setFocus] = useState(false);
   const input = useInput("");
 
@@ -40,7 +41,12 @@ const SigninInput = ({ title, type, name, id }: Props) => {
         name={name}
         id={id}
         value={input.value}
-        onChange={input.onChange}
+        onChange={(e) => {
+          input.onChange(e);
+          if (onInputChange) {
+            onInputChange(e.target.value);
+          }
+        }}
         ref={inputRef}
         onFocus={() => {
           setFocus(true);

--- a/src/app/email-signin/_component/TermsForm.tsx
+++ b/src/app/email-signin/_component/TermsForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 interface Props {
@@ -7,6 +8,8 @@ interface Props {
 }
 
 const TermsForm = ({ setTermsForm }: Props) => {
+  const router = useRouter();
+
   const [action, setAction] = useState(true);
 
   return (
@@ -54,7 +57,7 @@ const TermsForm = ({ setTermsForm }: Props) => {
           <div className="relative flex items-center">
             <div className="flex items-center mr-2 mb-2 p-1">
               <input type="checkbox" className="hidden" />
-              <button type="button" className="">
+              <button type="button">
                 <img src="./icons/allCheckIcon.svg" alt="전체 동의" />
               </button>
             </div>
@@ -93,7 +96,7 @@ const TermsForm = ({ setTermsForm }: Props) => {
             <div className="flex items-center mr-2">
               <input type="checkbox" className="hidden" />
               <button type="button" className="w-[25px]">
-                <img src="./icons/checkIcon.svg" alt="체크" width="100%" />
+                <img src="./icons/checkIcon.svg" alt="체크" />
               </button>
             </div>
             <div>
@@ -125,7 +128,10 @@ const TermsForm = ({ setTermsForm }: Props) => {
           <button
             type="button"
             className="w-full h-[56px] disabled:bg-grey-3 hover:bg-[#bb1e4a] bg-pink disabled:text-grey-4 text-[18px] text-white font-semibold rounded-xl"
-            disabled
+            // disabled
+            onClick={() => {
+              router.push("/email-signup");
+            }}
           >
             동의하고 계속하기
           </button>

--- a/src/app/email-signin/page.tsx
+++ b/src/app/email-signin/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import SigninHeader from "../signin/_component/SigninHeader";
+import DefaultHeader from "../_component/DefaultHeader";
 import EmailSigninForm from "./_component/EmailSigninForm";
 
 export const metadata: Metadata = {
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 const EmailSigninPage = () => {
   return (
     <div className="w-full">
-      <SigninHeader text="이메일로 로그인" redirectUrl="/signin" />
+      <DefaultHeader text="이메일로 로그인" redirectUrl="/signin" />
       <div className="flex flex-col">
         <EmailSigninForm />
       </div>

--- a/src/app/email-signup/page.tsx
+++ b/src/app/email-signup/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import SigninHeader from "../signin/_component/SigninHeader";
+import DefaultHeader from "../_component/DefaultHeader";
 
 const EmailSignupPage = () => {
   const [step] = useState(1);
 
   return (
     <section>
-      <SigninHeader
+      <DefaultHeader
         text="회원가입 "
         subText={`(${step}/2)`}
         redirectUrl="/email-signin"

--- a/src/app/email-signup/page.tsx
+++ b/src/app/email-signup/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useState } from "react";
+import SigninHeader from "../signin/_component/SigninHeader";
+
+const EmailSignupPage = () => {
+  const [step] = useState(1);
+
+  return (
+    <section>
+      <SigninHeader
+        text="회원가입 "
+        subText={`(${step}/2)`}
+        redirectUrl="/email-signin"
+      />
+    </section>
+  );
+};
+
+export default EmailSignupPage;

--- a/src/app/signin/_component/SigninHeader.tsx
+++ b/src/app/signin/_component/SigninHeader.tsx
@@ -3,28 +3,40 @@ import Link from "next/link";
 interface Props {
   text: string;
   subText?: string;
-  redirectUrl: string;
+  redirectUrl?: string;
+  theme?: string;
 }
 
-const SigninHeader = ({ text, subText, redirectUrl }: Props) => {
+const SigninHeader = ({
+  text,
+  subText = "",
+  redirectUrl,
+  theme = "default",
+}: Props) => {
   return (
     <div className="flex relative h-[48px]">
-      <Link
-        href={redirectUrl}
-        className="absolute left-[32px] top-1/2 -translate-y-1/2"
-      >
-        <img src="./icons/leftArrowIcon.svg" alt="왼쪽 화살표" width="24px" />
-      </Link>
+      {redirectUrl && (
+        <Link
+          href={redirectUrl}
+          className="absolute left-[32px] top-1/2 -translate-y-1/2"
+        >
+          <img src="./icons/leftArrowIcon.svg" alt="왼쪽 화살표" width="24px" />
+        </Link>
+      )}
+
       <div className="absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2 text-[18px] text-black-2 font-semibold">
-        <span>{text}</span>
-        <span className="font-thin">{subText}</span>
+        {theme === "default" && (
+          <>
+            <span>{text}</span>
+            <span className="font-thin">{subText}</span>
+          </>
+        )}
+        {theme === "main" && (
+          <img src="./icons/mainTitle.svg" alt="메인 로고" width={75} />
+        )}
       </div>
     </div>
   );
-};
-
-SigninHeader.defaultProps = {
-  subText: "",
 };
 
 export default SigninHeader;

--- a/src/app/signin/_component/SigninHeader.tsx
+++ b/src/app/signin/_component/SigninHeader.tsx
@@ -2,10 +2,11 @@ import Link from "next/link";
 
 interface Props {
   text: string;
+  subText?: string;
   redirectUrl: string;
 }
 
-const SigninHeader = ({ text, redirectUrl }: Props) => {
+const SigninHeader = ({ text, subText, redirectUrl }: Props) => {
   return (
     <div className="flex relative h-[48px]">
       <Link
@@ -15,10 +16,15 @@ const SigninHeader = ({ text, redirectUrl }: Props) => {
         <img src="./icons/leftArrowIcon.svg" alt="왼쪽 화살표" width="24px" />
       </Link>
       <div className="absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2 text-[18px] text-black-2 font-semibold">
-        {text}
+        <span>{text}</span>
+        <span className="font-thin">{subText}</span>
       </div>
     </div>
   );
+};
+
+SigninHeader.defaultProps = {
+  subText: "",
 };
 
 export default SigninHeader;


### PR DESCRIPTION
## 구현 내용
- 로그인 페이지에서 사용하는 input의 반복되는 애니메이션 때문에 컴포넌트를 분리하였습니다. (이 후 모든 input에 대한 공통 컴포넌트로의 변경을 논의할 예정입니다)
- 헤더 컴포넌트의 테마 속성을 추가하였습니다. 이후 마이 페이지에서의 메뉴 버튼이나 다른 추가 요소는 해당 컴포넌트가 만들어진 후 portals나 조건을 통하여 추가할 예정입니다. 세부적인 스타일 요소도 언제든 수정될 수 있다는 점 참고해주세요. (아래 예시 참조)
- button에 대한 컴포넌트를 생성하였고 테마를 추가하였습니다.  세부적인 스타일 요소도 언제든 수정될 수 있다는 점 참고해주세요. (아래 예시 참조)

### DefaultHeader 컴포넌트
```javascript
{
  text: string;  // 화면에 표시될 글자
  subText?: string; // 화면에 연한 색상으로 표시될 글자
  redirectUrl?: string; // 버튼 클릭 시 이동할 주소 (입력 안 하면 이동 버튼 안 생김)
  theme?: string; // 원하는 테마 (기본 값: default)
}
```
사용
```javascript
<DefaultHeader text="이메일로 로그인" redirectUrl="/signin" />
```

![스크린샷 2024-01-03 233557](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/96133f88-f17d-4efa-a668-b362c152620d)

```javascript
<DefaultHeader
    text="회원가입 "
    subText={`(${step}/2)`}
    redirectUrl="/email-signin"
/>
```

![스크린샷 2024-01-03 235051](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/80ec90f9-2756-4061-b8d4-ec933bd5a877)

```javascript
<DefaultHeader text="이메일로 로그인" redirectUrl="/signin" theme="main"/>
```

![스크린샷 2024-01-03 233720](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/8580de3c-0772-4d1f-a13b-26fe9fb11e95)

```javascript
<DefaultHeader text="이메일로 로그인" theme="main"/>
```

![스크린샷 2024-01-03 233835](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/5996f0c3-c232-4278-84cb-6618f0da48a9)

### Button 컴포넌트
```javascript
{
  text: string; // 버튼 글자
  styleClass?: string; // 스타일 적용할 테일윈드 class (기존 테마 스타일에서 덮어씌우기 가능)
  onClickFn?: () => void; // 클릭 이벤트 함수
  disabled?: boolean;
  theme?: string; // 테마
}
```
사용
```javascript
<Button
   text="로그인"
   disabled={emailValue === "" || passwordValue === ""}
   theme="wide" // 아래 이미지와 같이 넓은 메인 버튼이 만들어짐
 />
```
![스크린샷 2024-01-03 235632](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/880da900-c9a5-45c1-8223-9a9a185ac7b2)
![스크린샷 2024-01-03 235625](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/73ced51a-88ee-4e5f-b3e4-d3db29cd5e51)

```javascript
<Button
   text="비밀번호 재설정"
   theme="md" // padding이 8px 들어간 아무 스타일적인 요소가 없는 버튼이 만들어짐
   onClickFn={() => {
     router.push("/signin");
   }}
 />
```
![스크린샷 2024-01-03 235639](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/469e5096-c4d9-4925-9b97-16d85897fbc7)

## 기타
- 브랜치 삭제 X

## 이슈번호
X
