### PR TITLE
Feat: 공통 탭 컴포넌트 생성 및 마이페이지 퍼블리싱

### DIFF
--- a/src/app/_component/common/TabButtons.tsx
+++ b/src/app/_component/common/TabButtons.tsx
@@ -1,0 +1,28 @@
+import Button from "./Button";
+
+interface Props {
+  tabName: string;
+  onClick: () => void;
+  isSelected: boolean;
+  defaultClass?: string;
+  selectedClass?: string;
+}
+
+const TabButtons = ({
+  tabName,
+  onClick,
+  isSelected,
+  defaultClass = "text-gray-400",
+  selectedClass = "text-black",
+}: Props) => {
+  const styleClass = isSelected
+    ? `w-full font-bold shrink-0 ${selectedClass}`
+    : `w-full shrink-0 ${defaultClass}`;
+  return (
+    <li className="flex w-full text-center text-sm">
+      <Button text={tabName} styleClass={styleClass} onClickFn={onClick} />
+    </li>
+  );
+};
+
+export default TabButtons;

--- a/src/app/_component/common/Tabs.tsx
+++ b/src/app/_component/common/Tabs.tsx
@@ -1,0 +1,18 @@
+import React, { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  buttons: ReactNode[];
+}
+const Tabs = ({ children, buttons }: Props) => {
+  return (
+    <>
+      <ul className="flex items-center justify-start overflow-x-auto">
+        {buttons}
+      </ul>
+      {children}
+    </>
+  );
+};
+
+export default Tabs;

--- a/src/app/_component/common/TabsContainer.tsx
+++ b/src/app/_component/common/TabsContainer.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Tabs from "@/app/_component/common/Tabs";
 import TabButtons from "@/app/_component/common/TabButtons";
 
-export interface Props {
+interface Props {
   tabs: {
     name: string;
     content: JSX.Element;

--- a/src/app/_component/common/TabsContainer.tsx
+++ b/src/app/_component/common/TabsContainer.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import Tabs from "@/app/_component/common/Tabs";
+import TabButtons from "@/app/_component/common/TabButtons";
+
+export interface Props {
+  tabs: {
+    name: string;
+    content: JSX.Element;
+  }[];
+  tabButtonStyle?: {
+    defaultClass?: string;
+    selectedClass?: string;
+  };
+}
+
+const TabsContainer = ({ tabs, tabButtonStyle }: Props) => {
+  const [selectedTab, setSelectedTab] = useState<string>(tabs[0].name);
+
+  const handleSelect = (tabName: string) => {
+    setSelectedTab(tabName);
+  };
+  return (
+    <article>
+      <Tabs
+        buttons={tabs.map((tab) => (
+          <TabButtons
+            isSelected={selectedTab === tab.name}
+            key={tab.name}
+            onClick={() => handleSelect(tab.name)}
+            tabName={tab.name}
+            defaultClass={tabButtonStyle?.defaultClass}
+            selectedClass={tabButtonStyle?.selectedClass}
+          />
+        ))}
+      >
+        {tabs.find((tab) => tab.name === selectedTab)?.content}
+      </Tabs>
+    </article>
+  );
+};
+
+export default TabsContainer;

--- a/src/app/my/_component/MyReviewTabContent.tsx
+++ b/src/app/my/_component/MyReviewTabContent.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Button from "@/app/_component/common/Button";
+import renderStars from "@/utils/renderStars";
+
+const averageScore = 3.5;
+
+const MyReviewTabContent = () => {
+  return (
+    <>
+      <ul className="flex flex-col gap-2 justify-start items-center w-[95%]  mx-auto my-4 ">
+        <li className="w-full flex flex-col gap-2 border border-black border-solid py-3  px-2 rounded">
+          <h2 className="font-bold text-md"> review.content</h2>
+          <div className="flex items-center text-xs text-grey-4">
+            <div className="flex gap-.5 ">{renderStars(averageScore)}</div>
+            <span className="flex gap-2 ml-2">
+              <span>({averageScore})</span>
+              <span> 2024.01.01</span>
+            </span>
+          </div>
+
+          <div className="flex p-2 bg-gray-200	gap-2 bg-grey rounded-md text-xs">
+            <dl className="flex gap-0.5">
+              <dt className="text-black-6">상품구성</dt>
+              <dd className="text-pink"> 4</dd>
+            </dl>
+            <dl className="flex gap-0.5">
+              <dt className="text-black-6">가이드 친절도</dt>
+              <dd className="text-pink"> 5</dd>
+            </dl>
+
+            <dl className="flex gap-0.5">
+              <dt className="text-black-6">일정구성</dt>
+              <dd className="text-pink"> 5</dd>
+            </dl>
+
+            <dl className="flex gap-0.5">
+              <dt className="text-black-6">가이드 시간/일정준수</dt>
+              <dd className="text-pink"> 4</dd>
+            </dl>
+          </div>
+        </li>
+      </ul>
+      {/* //TODO: bottomNav 높이만큼 bottom 값 수정하기 */}
+      <Button
+        text="더보기"
+        styleClass="bg-gray-100 w-full flex justify-center gap-4 z-5  text-center items-center py-2 fixed bottom-[60px]"
+        icon="/icons/bottomArrowIcon.svg"
+      />
+    </>
+  );
+};
+
+export default MyReviewTabContent;

--- a/src/app/my/_component/ReservationTabContent.tsx
+++ b/src/app/my/_component/ReservationTabContent.tsx
@@ -1,0 +1,49 @@
+import Button from "@/app/_component/common/Button";
+import React from "react";
+
+const ReservationTabContent = () => {
+  return (
+    <>
+      <ul className="flex flex-col gap-2 justify-start items-center w-[95%]  mx-auto my-4 ">
+        <li className="w-full relative p-3 flex flex-row gap-2 border border-solid border-black rounded-md">
+          <div className=" basis-1/3 rounded-md overflow-hidden">
+            <img
+              className="w-full h-full"
+              src="//source.unsplash.com/100x100?japan"
+              alt="예약내역 이미지"
+            />
+          </div>
+          <div className="flex flex-col justify-center px-3 basis-2/3 gap-2">
+            <p className="flex flex-row items-center gap-10 ">
+              <span className="font-bold text-md ">
+                청룡의 해 얼리버드 특가
+              </span>
+            </p>
+            <p className="flex flex-row items-center justify-start gap-1">
+              <span className="border border-solid border-grey-4 rounded p-1 text-xs">
+                일본
+              </span>
+              <span className="border border-solid border-grey-4 rounded p-1 text-xs">
+                체험/액티비티
+              </span>
+              <span className="border border-solid border-grey-4 rounded p-1 text-xs">
+                쇼핑
+              </span>
+            </p>
+            <Button
+              text="리뷰 보러 가기"
+              styleClass="rounded text-xs p-2 px-4 mt-4 bg-pink text-white"
+            />
+          </div>
+        </li>
+      </ul>
+      <Button
+        text="더보기"
+        styleClass="bg-gray-100 w-full flex justify-center gap-4 z-5  text-center items-center py-2 fixed bottom-[60px]"
+        icon="/icons/bottomArrowIcon.svg"
+      />
+    </>
+  );
+};
+
+export default ReservationTabContent;

--- a/src/app/my/_component/TabTest.tsx
+++ b/src/app/my/_component/TabTest.tsx
@@ -1,0 +1,70 @@
+// TODO:::이후 제거할 예정입니당
+
+import React from "react";
+import TabsContainer from "@/app/_component/common/TabsContainer";
+import ReservationTabContent from "./ReservationTabContent";
+import MyReviewTabContent from "./MyReviewTabContent";
+
+export const Test1 = () => {
+  return <div className="text-center p-5">탭 콘텐츠 컴포넌트</div>;
+};
+export const Test2 = () => {
+  return <div className="text-center p-5">탭 콘텐츠 컴포넌트</div>;
+};
+export const Test3 = () => {
+  return <div className="text-center p-5">탭 콘텐츠 컴포넌트</div>;
+};
+
+const TabTest = () => {
+  const tabsData = [
+    { name: "예약 내역", content: <ReservationTabContent /> },
+    { name: "내가 쓴 리뷰", content: <MyReviewTabContent /> },
+  ];
+  const tabsData1 = [
+    { name: "test1", content: <Test1 /> },
+    { name: "test2", content: <Test2 /> },
+    { name: "test3", content: <Test3 /> },
+  ];
+  const tabsData2 = [
+    { name: "test1", content: <Test1 /> },
+    { name: "test2", content: <Test2 /> },
+    { name: "test3", content: <Test3 /> },
+    { name: "test4", content: <Test1 /> },
+    { name: "test5", content: <Test2 /> },
+    { name: "test6", content: <Test3 /> },
+    { name: "test7", content: <Test1 /> },
+    { name: "test8", content: <Test2 /> },
+    { name: "test9", content: <Test1 /> },
+    { name: "test10", content: <Test2 /> },
+  ];
+  return (
+    <>
+      <TabsContainer
+        tabs={tabsData}
+        tabButtonStyle={{
+          defaultClass: "py-3 text-black",
+          selectedClass:
+            "py-3 font-black border-b border-0.5 border-solid border-black",
+        }}
+      />
+      <TabsContainer
+        tabs={tabsData1}
+        tabButtonStyle={{
+          defaultClass: "py-2 border-b border-1 border-gray-400",
+          selectedClass:
+            "py-2 text-black border-b border-1 border-pink border-solid",
+        }}
+      />
+
+      <TabsContainer
+        tabs={tabsData2}
+        tabButtonStyle={{
+          defaultClass: "pl-4 py-2",
+          selectedClass: "text-pink pl-4 py-2 :last-child:pr-3",
+        }}
+      />
+    </>
+  );
+};
+
+export default TabTest;

--- a/src/app/my/_component/UpcomingPackages.tsx
+++ b/src/app/my/_component/UpcomingPackages.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Button from "@/app/_component/common/Button";
+
+const UpcomingPackages = () => {
+  return (
+    <article className="w-[95%] mx-auto my-4">
+      <h2 className="w-full font-bold text-md p-2">
+        다가오는 패키지가 있어요!
+      </h2>
+      <div className="p-3 flex flex-row flex-wrap relative border border-solid border-black rounded-md">
+        <div className=" basis-1/5 rounded-md overflow-hidden">
+          <img
+            className="w-full h-full"
+            src="//source.unsplash.com/66x66?osaka"
+            alt="다가오는 패키지"
+          />
+        </div>
+        <div className="flex flex-col justify-center px-3 basis-4/5 gap-1">
+          <p className="flex flex-row items-center gap-5 ">
+            <span className="font-semibold text-md ">오사카 특별 패키지</span>
+            <span className="font-semibold text-md text-pink">D - 30</span>
+          </p>
+          <p className="flex flex-row items-center gap-2 text-grey-4">
+            <span>일본</span>
+            <span className="text-sm">23.01.01 - 23.01.01</span>
+          </p>
+          <Button
+            text="전체보기"
+            theme="md"
+            styleClass="absolute bottom-1 right-1 text-xs underline underline-offset-4  text-slate-500 decoration-slate-400"
+          />
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default UpcomingPackages;

--- a/src/app/my/_component/UserInfo.tsx
+++ b/src/app/my/_component/UserInfo.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+const UserInfo = () => {
+  return (
+    <article className="flex  flex-col justify-center items-center bg-gray-200 gap-2 p-5">
+      <p className="flex items-center gap-3 font-bold text-lg">
+        data.nickname
+        <span>
+          <img src="./icons/editIcon.svg" alt="내 정보 수정" />
+        </span>
+      </p>
+      <p className="text-sm"> email@email.com</p>
+    </article>
+  );
+};
+
+export default UserInfo;

--- a/src/app/my/_test/Mypage.test.tsx
+++ b/src/app/my/_test/Mypage.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@/app/test-utils";
+import Signin from "../page";
+
+jest.mock("next/navigation", () => ({
+  useRouter() {
+    return {
+      prefetch: () => null,
+    };
+  },
+}));
+describe("Signin", () => {
+  it("로그인 페이지 라는 문구가 있어야 한다.", async () => {
+    render(<Signin />);
+
+    const el = screen.getByText("로그인 페이지");
+
+    expect(el).toBeInTheDocument();
+  });
+});

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,0 +1,37 @@
+import BottomNav from "../_component/common/BottomNav";
+import UpcomingPackages from "./_component/UpcomingPackages";
+import UserInfo from "./_component/UserInfo";
+import DefaultHeader from "../_component/common/DefaultHeader";
+import ReservationTabContent from "./_component/ReservationTabContent";
+import MyReviewTabContent from "./_component/MyReviewTabContent";
+import TabsContainer from "../_component/common/TabsContainer";
+
+export function generateMetadata() {
+  return { title: "Let's - 마이페이지" };
+}
+
+const MyPage = async () => {
+  const tabsData = [
+    { name: "예약 내역", content: <ReservationTabContent /> },
+    { name: "내가 쓴 리뷰", content: <MyReviewTabContent /> },
+  ];
+
+  return (
+    <section className="w-full flex flex-col">
+      <DefaultHeader text="마이페이지" redirectUrl="/" theme="default" />
+      <UserInfo />
+      <UpcomingPackages />
+      <TabsContainer
+        tabs={tabsData}
+        tabButtonStyle={{
+          defaultClass: "py-3 text-black",
+          selectedClass:
+            "py-3 font-black border-b border-0.5 border-solid border-black",
+        }}
+      />
+      <BottomNav />
+    </section>
+  );
+};
+
+export default MyPage;

--- a/src/utils/renderStars.tsx
+++ b/src/utils/renderStars.tsx
@@ -1,0 +1,62 @@
+const renderStars = (averageScore: number) => {
+  const totalStars = Array.from({ length: 5 }, (_, index) => index + 1);
+
+  return totalStars.map((starNumber) => {
+    let svgContent;
+
+    if (starNumber <= Math.floor(averageScore)) {
+      // 노란 별 SVG
+      svgContent = (
+        <>
+          <path
+            d="M9.9834 16.5L12.7676 11.4478L18.4834 10.3885L14.4884 6.20686L15.2367 0.5L9.9834 2.96779L4.73011 0.5L5.4784 6.20686L1.4834 10.3885L7.19916 11.4478L9.9834 16.5Z"
+            fill="#FDBD00"
+          />
+          <path
+            d="M9.9834 16.5V12.5V10.5V8.5V5.5V3L4.4834 0L5.4834 6L0.983398 10.5L6.9834 11.4478L9.9834 16.5Z"
+            fill="#FDBD00"
+          />
+        </>
+      );
+    } else if (
+      starNumber === Math.ceil(averageScore) &&
+      averageScore % 1 !== 0
+    ) {
+      // 반쪽 별 SVG
+      svgContent = (
+        <>
+          <path
+            d="M9 16.5L11.7842 11.4478L17.5 10.3885L13.505 6.20686L14.2533 0.5L9 2.96779L3.74671 0.5L4.495 6.20686L0.5 10.3885L6.21576 11.4478L9 16.5Z"
+            fill="#CCCAC3"
+          />
+          <path
+            d="M9 16.5V12.5V10.5V8.5V5.5V3L3.5 0L4.5 6L0 10.5L6 11.4478L9 16.5Z"
+            fill="#FDBD00"
+          />
+        </>
+      );
+    } else {
+      // 회색 별 SVG
+      svgContent = (
+        <path
+          d="M8.5 16L11.2842 10.9478L17 9.88854L13.005 5.70686L13.7533 0L8.5 2.46779L3.24671 0L3.995 5.70686L0 9.88854L5.71576 10.9478L8.5 16Z"
+          fill="#CCCAC3"
+        />
+      );
+    }
+
+    return (
+      <svg
+        key={starNumber}
+        width="12"
+        height="12"
+        viewBox="0 0 19 17"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {svgContent}
+      </svg>
+    );
+  });
+};
+
+export default renderStars;


### PR DESCRIPTION
## 구현 내용

 ![image](https://github.com/yanolja-finalproject/LETS_FE/assets/131247158/842729d0-9b26-4bb4-bdcc-ccebd4518492) 


![Image 760](https://github.com/yanolja-finalproject/LETS_FE/assets/131247158/94900458-4bcc-4fe4-a6a7-ec319500239f)  ![Image 759](https://github.com/yanolja-finalproject/LETS_FE/assets/131247158/20b066ed-e771-44f3-b572-b9368428740b) 


- 공통 탭 컴포넌트 생성
- 마이페이지 퍼블리싱

공통 탭 컴포넌트 생성하였습니다!


#### TabsContainer 컴포넌트: 탭의 전체적인 상태 관리와 레이아웃
- tabs prop을 통해 탭의 이름과 내용을 배열로 받습니다.
- tabButtonStyle prop을 통해 선택된 탭(defaultClass)과 기본 탭(selectedClass)의 스타일을 정의합니다.

#### Tabs 컴포넌트: 탭 메뉴, 탭 콘텐츠 렌더링
- 탭 버튼(buttons)과 탭 컨텐츠(children)를 받아 렌더링합니다.
- 탭 버튼들을 감싸고 있는 ul 태그에 overflow-x-auto 속성 주어 가로 스크롤 가능하도록 하였습니다.

#### TabButtons 컴포넌트
- tabName, onClick, isSelected,defaultClass, selectedClass을 props로 받습니다.

### 사용 예시
```javascript

const TabTest = () => {

  const tabsData = [
    { name: "test1", content: <Test1 /> },
    { name: "test2", content: <Test2 /> },
    { name: "test3", content: <Test3 /> },
  ];
  return (
    <>
      <TabsContainer
        tabs={tabsData}
        tabButtonStyle={{
          defaultClass: "py-2 border-b border-1 border-gray-400",
          selectedClass:
            "py-2 text-black border-b border-1 border-pink border-solid",
        }}
      />
    </>
  );
};

export default TabTest;

```

좀 더 단순하게 구성하고 싶었는데 쉽지 않네요..😭 좋은 의견 있으시면 말씀해주세요!


