### PR TITLE
Feat: 이메일 인증 카운트 추가

### DIFF
--- a/src/app/(non-navbar)/email-signin/_component/CertificationCount.tsx
+++ b/src/app/(non-navbar)/email-signin/_component/CertificationCount.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import useSignupStateStore from "@/store/useSignupStateStore";
+import { useEffect, useState } from "react";
+
+const CertificationCount = () => {
+  const signupState = useSignupStateStore();
+
+  const [time, setTime] = useState(5);
+  const [fontColor, setFontColor] = useState("");
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+    if (signupState.isCertification) {
+      interval = setInterval(() => {
+        setTime((prev) => prev - 1);
+      }, 1000);
+    }
+
+    if (time === 0) {
+      setFontColor("red");
+      setTime(5);
+      signupState.setIsCertification(false);
+    }
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [time, signupState]);
+
+  const formatTime = (timer: number): string => {
+    const minutes = Math.floor(timer / 60);
+    const seconds = timer % 60;
+    return `${minutes.toString().padStart(2, "0")} : ${seconds
+      .toString()
+      .padStart(2, "0")}`;
+  };
+
+  return <div className={`text-${fontColor}`}>{formatTime(time)}</div>;
+};
+
+export default CertificationCount;

--- a/src/app/(non-navbar)/email-signin/_component/CertificationCount.tsx
+++ b/src/app/(non-navbar)/email-signin/_component/CertificationCount.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import {
+  COUNT_DIGIT,
+  ONE_MINUTE,
+  ONE_SECOND,
+  THOUSAND_MILLISECONDS,
+} from "@/app/constants";
 import useSignupStateStore from "@/store/useSignupStateStore";
 import { useEffect, useState } from "react";
 
@@ -13,8 +19,8 @@ const CertificationCount = () => {
     let interval: NodeJS.Timeout;
     if (signupState.isCertification) {
       interval = setInterval(() => {
-        setTime((prev) => prev - 1);
-      }, 1000);
+        setTime((prev) => prev - ONE_SECOND);
+      }, THOUSAND_MILLISECONDS);
     }
 
     if (time === 0) {
@@ -29,11 +35,11 @@ const CertificationCount = () => {
   }, [time, signupState]);
 
   const formatTime = (timer: number): string => {
-    const minutes = Math.floor(timer / 60);
-    const seconds = timer % 60;
-    return `${minutes.toString().padStart(2, "0")} : ${seconds
+    const minutes = Math.floor(timer / ONE_MINUTE);
+    const seconds = timer % ONE_MINUTE;
+    return `${minutes.toString().padStart(COUNT_DIGIT, "0")} : ${seconds
       .toString()
-      .padStart(2, "0")}`;
+      .padStart(COUNT_DIGIT, "0")}`;
   };
 
   return <div className={`text-${fontColor}`}>{formatTime(time)}</div>;

--- a/src/app/(non-navbar)/email-signin/_component/EmailSigninForm.tsx
+++ b/src/app/(non-navbar)/email-signin/_component/EmailSigninForm.tsx
@@ -2,6 +2,7 @@
 
 import postSignin from "@/api/signin/postSignin";
 import Button from "@/app/_component/common/atom/Button";
+import useSignupStateStore from "@/store/useSignupStateStore";
 import validateEmail from "@/utils/validateEmail";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -11,6 +12,7 @@ import TermsForm from "./TermsForm";
 
 const EmailSigninForm = () => {
   const router = useRouter();
+  const signupState = useSignupStateStore();
 
   const [termsForm, setTermsForm] = useState(false);
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
@@ -18,6 +20,13 @@ const EmailSigninForm = () => {
   useEffect(() => {
     setPortalElement(document.getElementById("portal"));
   }, [termsForm]);
+
+  useEffect(() => {
+    signupState.setIsCertification(false);
+    signupState.setIsSignup(false);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [emailValue, setEmailValue] = useState("");
   const [passwordValue, setPasswordValue] = useState("");

--- a/src/app/(non-navbar)/email-signin/_component/SigninInput.tsx
+++ b/src/app/(non-navbar)/email-signin/_component/SigninInput.tsx
@@ -2,7 +2,9 @@
 
 import Button from "@/app/_component/common/atom/Button";
 import useInput from "@/hooks/useInput";
+import useSignupStateStore from "@/store/useSignupStateStore";
 import { useRef, useState } from "react";
+import CertificationCount from "./CertificationCount";
 import SignupErrorText from "./SignupErrorText";
 
 interface Props {
@@ -26,6 +28,8 @@ const SigninInput = ({
   onClickFn,
   onInputChange,
 }: Props) => {
+  const signupState = useSignupStateStore();
+
   const [focus, setFocus] = useState(false);
   const input = useInput("");
 
@@ -74,7 +78,7 @@ const SigninInput = ({
 
       {theme === "button" && (
         <Button
-          text="인증 요청"
+          text={signupState.isCertification ? "다시 요청" : "인증 요청"}
           theme="md"
           styleClass="text-blue rounded-lg bg-white absolute top-1/2 right-[6px] -translate-y-1/2  disabled:text-blue-transparent  disabled:bg-[rgba(255,255,255,0.7)]"
           disabled={input.value === ""}
@@ -84,7 +88,7 @@ const SigninInput = ({
 
       {theme === "count" && (
         <div className="text-blue text-sm absolute top-1/2 right-4 -translate-y-1/2 web:right-6">
-          <div>06 : 13</div>
+          <CertificationCount />
         </div>
       )}
 

--- a/src/app/(non-navbar)/email-signin/_component/TermsForm.tsx
+++ b/src/app/(non-navbar)/email-signin/_component/TermsForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Button from "@/app/_component/common/atom/Button";
+import useSignupStateStore from "@/store/useSignupStateStore";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import AllselectCheckbox from "./AllselectCheckbox";
@@ -11,6 +12,7 @@ interface Props {
 }
 
 const TermsForm = ({ setTermsForm }: Props) => {
+  const signupState = useSignupStateStore();
   const router = useRouter();
 
   const [action, setAction] = useState(true);
@@ -23,6 +25,7 @@ const TermsForm = ({ setTermsForm }: Props) => {
   };
 
   const handleAgree = () => {
+    signupState.setIsSignup(true);
     router.push("/email-signup");
   };
 

--- a/src/app/(non-navbar)/email-signup/_component/EmailAuth.tsx
+++ b/src/app/(non-navbar)/email-signup/_component/EmailAuth.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import postCertification from "@/api/signin/postCertification";
 import getEmailAuth from "@/api/signin/getEmailAuth";
+import postCertification from "@/api/signin/postCertification";
 import SigninInput from "@/app/(non-navbar)/email-signin/_component/SigninInput";
 import Button from "@/app/_component/common/atom/Button";
 import useSignupInfoStore from "@/store/useSignupInfoStore";
@@ -23,26 +23,35 @@ const EmailAuth = ({ setStep }: Props) => {
   const [emailValue, setEmailValue] = useState("");
   const [codeValue, setCodeValue] = useState("");
   const [emailErrorMessage, setEmailErrorMessage] = useState("");
+  const [codeErrorMessage, setCodeErrorMessage] = useState("");
 
   const handleNextStep = async () => {
-    const data = await getEmailAuth(emailValue, codeValue);
+    if (signupState.isCertification) {
+      const data = await getEmailAuth(emailValue, codeValue);
 
-    if (data.code === 200) {
-      signupState.setCertificated();
-      signupInfo.updateEmail(emailValue);
-      setStep(2);
+      if (data.code === 200) {
+        signupState.setCertificated(true);
+        signupInfo.updateEmail(emailValue);
+        setStep(2);
+      }
+    } else {
+      setCodeErrorMessage("인증 시간이 만료되었습니다. 다시 요청해 주세요!");
     }
   };
 
   const handleEmailInputChange = (inputValue: string) => {
     setEmailValue(inputValue);
-    setCertification(false);
+    signupState.setIsCertification(false);
   };
   const handleCodeInputChange = (inputValue: string) => {
     setCodeValue(inputValue);
   };
 
   const handleCertification = async () => {
+    signupState.setIsCertification(false);
+    setCertification(false);
+    setCodeValue("");
+    setCodeErrorMessage("");
     if (!validateEmail(emailValue)) {
       setEmailErrorMessage("잘못된 유형의 이메일 입니다. 수정해주세요.");
     } else {
@@ -53,6 +62,7 @@ const EmailAuth = ({ setStep }: Props) => {
 
       if (data.code === 200) {
         console.log("인증번호 요청 성공");
+        signupState.setIsCertification(true);
         setCertification(true);
       }
     }
@@ -80,6 +90,7 @@ const EmailAuth = ({ setStep }: Props) => {
             title="인증번호"
             type="number"
             theme="count"
+            errorMessage={codeErrorMessage}
             onInputChange={handleCodeInputChange}
           />
         </div>

--- a/src/app/(non-navbar)/email-signup/_component/EnterPassword.tsx
+++ b/src/app/(non-navbar)/email-signup/_component/EnterPassword.tsx
@@ -49,7 +49,8 @@ const EnterPassword = ({ setStep }: Props) => {
           id: signupInfo.email,
           password: passwordValue,
         });
-        if (signinData.code) {
+        if (signinData.code === 200) {
+          signupState.setIsSignup(false);
           setStep(4);
         }
       }

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -1,0 +1,4 @@
+export const THOUSAND_MILLISECONDS = 1000;
+export const ONE_SECOND = 1;
+export const ONE_MINUTE = 60;
+export const COUNT_DIGIT = 2;

--- a/src/store/useSignupInfoStore.ts
+++ b/src/store/useSignupInfoStore.ts
@@ -2,19 +2,15 @@ import { create } from "zustand";
 
 interface Props {
   email: string;
-  password: string;
   name: string;
   updateEmail: (email: string) => void;
-  updatePassword: (password: string) => void;
   updateName: (name: string) => void;
 }
 
 const useSignupInfoStore = create<Props>((set) => ({
   email: "",
-  password: "",
   name: "",
   updateEmail: (email) => set(() => ({ email })),
-  updatePassword: (password) => set(() => ({ password })),
   updateName: (name) => set(() => ({ name })),
 }));
 

--- a/src/store/useSignupStateStore.ts
+++ b/src/store/useSignupStateStore.ts
@@ -2,16 +2,20 @@ import { create } from "zustand";
 
 interface Props {
   isSignup: boolean;
+  isCertification: boolean;
   certificated: boolean;
-  setCertificated: VoidFunction;
-  setIsSignup: VoidFunction;
+  setCertificated: (state: boolean) => void;
+  setIsSignup: (state: boolean) => void;
+  setIsCertification: (state: boolean) => void;
 }
 
 const useSignupStateStore = create<Props>((set) => ({
   isSignup: false,
+  isCertification: false,
   certificated: false,
-  setCertificated: () => set({ certificated: true }),
-  setIsSignup: () => set({ isSignup: true }),
+  setCertificated: (state) => set({ certificated: state }),
+  setIsSignup: (state) => set({ isSignup: state }),
+  setIsCertification: (state) => set({ isCertification: state }),
 }));
 
 export default useSignupStateStore;


### PR DESCRIPTION
## 구현 내용
- 이메일 인증 시 카운트 다운이 진행 됩니다.
- 이메일 인증 상태를 스토어에 추가하였습니다.

![스크린샷 2024-01-09 222930](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/af386f4f-4330-4083-bb58-b8ec8e058c40)

## 기타
- 흐름을 파악하기 쉽도록 일단 카운트를 5초로 해 놓은 상태 입니다. (이후 수정 5분으로 변경 예정)

## 이슈번호
X
