### PR TITLE
Feat: 일정 선택 연도, 월 선택 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     "jsx-a11y/no-static-element-interactions": "off",
     "react/require-default-props": "off",
     "object-shorthand": 0,
-    "no-nested-ternary": "off"
+    "no-nested-ternary": "off",
+    "jsx-a11y/control-has-associated-label": "off"
   }
 }

--- a/public/icons/pageLeftIcon.svg
+++ b/public/icons/pageLeftIcon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M13 8.5L9.5 12L13 15.5" stroke="#666666" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 22C17.523 22 22 17.523 22 12C22 6.477 17.523 2 12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22Z" stroke="#666666" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/pageLeftIconLight.svg
+++ b/public/icons/pageLeftIconLight.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M13 8.5L9.5 12L13 15.5" stroke="#DDDDDD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 22C17.523 22 22 17.523 22 12C22 6.477 17.523 2 12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22Z" stroke="#DDDDDD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/pageRightIcon.svg
+++ b/public/icons/pageRightIcon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
+  <path d="M10 7.5L13.5 11L10 14.5" stroke="#666666" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M11 21C16.523 21 21 16.523 21 11C21 5.477 16.523 1 11 1C5.477 1 1 5.477 1 11C1 16.523 5.477 21 11 21Z" stroke="#666666" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/pageRightIconLight.svg
+++ b/public/icons/pageRightIconLight.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
+  <path d="M10 7.5L13.5 11L10 14.5" stroke="#666666" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M11 21C16.523 21 21 16.523 21 11C21 5.477 16.523 1 11 1C5.477 1 1 5.477 1 11C1 16.523 5.477 21 11 21Z" stroke="#DDDDDD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/(navbar)/payment/_component/ReservationInfo.tsx
+++ b/src/app/(navbar)/payment/_component/ReservationInfo.tsx
@@ -206,11 +206,10 @@ const ReservationInfo = ({ onComplete }: Props) => {
             </p>
           </div>
         </div>
-        
+
         <div className="flex justify-between mx-2 pt-4 px-8">
           <div className="flex items-center text-pink text-xs font-medium">
             <p>총 결제금액</p>
-
           </div>
           <div className="text-pink-main text-xl font-bold">
             <p>
@@ -319,7 +318,6 @@ const ReservationInfo = ({ onComplete }: Props) => {
         </p>
 
         <div className="flex justify-center my-6">
-
           <Button
             text="예약하기"
             styleClass="rounded-lg bg-pink text-white py-2 px-24 cursor-pointer"

--- a/src/app/(non-navbar)/schedule/[id]/_component/Calender.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/Calender.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+// import CalenderDays from "./CalenderDays";
+// import CalenderWeeks from "./CalenderWeeks";
+import { useEffect, useState } from "react";
+import CalenderHeader from "./CalenderHeader";
+import CalenderMonth from "./CalenderMonth";
+
+const Calender = () => {
+  const today = {
+    year: new Date().getFullYear(),
+    month: new Date().getMonth() + 1,
+    date: new Date().getDate(),
+    day: new Date().getDay(),
+  };
+
+  const [selectedYear, setSelectedYear] = useState(today.year);
+  const [selectedMonth, setSelectedMonth] = useState(today.month);
+
+  // 콘솔 확인용 제거 예정
+  // useEffect(() => {
+  //   console.log(selectedYear);
+  // }, [selectedYear]);
+
+  const monthlyDate = new Date(selectedYear, selectedMonth, 0).getDate();
+
+  // 콘솔 확인용 제거 예정
+  useEffect(() => {
+    console.log(monthlyDate);
+  }, [monthlyDate]);
+
+  return (
+    <div>
+      <CalenderHeader
+        selectedYear={selectedYear}
+        setSelectedYear={setSelectedYear}
+      />
+      {/* <CalenderWeeks /> */}
+      <CalenderMonth
+        todayMonth={today.month}
+        todayYear={today.year}
+        selectedYear={selectedYear}
+        setSelectedMonth={setSelectedMonth}
+      />
+      {/* <CalenderDays /> */}
+    </div>
+  );
+};
+
+export default Calender;

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderDays.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderDays.tsx
@@ -1,0 +1,9 @@
+const CalenderDays = () => {
+  return (
+    <div>
+      <h1>일일일일</h1>
+    </div>
+  );
+};
+
+export default CalenderDays;

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderHeader.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderHeader.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+interface Props {
+  selectedYear: number;
+  setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const CalenderHeader = ({ selectedYear, setSelectedYear }: Props) => {
+  const handleClickPrevYear = () => {
+    setSelectedYear((prev) => prev - 1);
+  };
+  const handleClickNextYear = () => {
+    setSelectedYear((prev) => prev + 1);
+  };
+
+  return (
+    <div className="flex items-center justify-between h-10 mt-9 web:mt-5">
+      <button type="button" onClick={handleClickPrevYear}>
+        <img
+          src="/icons/pageLeftIcon.svg"
+          alt="이전"
+          className="w-5 h-5 web:w-7 web:h-7"
+        />
+      </button>
+      <h1 className="text-base text-black-2 font-medium web:text-xl">
+        {selectedYear}
+      </h1>
+      <button type="button" onClick={handleClickNextYear}>
+        <img
+          src="/icons/pageRightIcon.svg"
+          alt="다음"
+          className="w-5 h-5 web:w-7 web:h-7"
+        />
+      </button>
+    </div>
+  );
+};
+
+export default CalenderHeader;

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderMonth.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderMonth.tsx
@@ -1,0 +1,55 @@
+import Button from "@/app/_component/common/atom/Button";
+
+interface Props {
+  todayYear: number;
+  todayMonth: number;
+  selectedYear: number;
+  setSelectedMonth: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const CalenderMonth = ({
+  todayYear,
+  todayMonth,
+  selectedYear,
+  setSelectedMonth,
+}: Props) => {
+  const Month = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+  const handleClickMonth = (month: number) => {
+    setSelectedMonth(month);
+  };
+
+  return (
+    <div className="flex flex-wrap mt-3 web:mt-5">
+      {Month.map((item, index) => {
+        return (
+          <div
+            key={item}
+            className={`flex justify-${
+              index % 3 === 1 ? "center" : index % 3 === 2 ? "end" : "start"
+            } items-center w-1/3 mb-3 web:w-1/4 web:justify-center`}
+          >
+            <Button
+              styleClass="flex justify-center items-center w-[98px] h-[79px] border-[0.6px] border-solid border-grey-a rounded-lg bg-white 
+              duration-100 active:bg-pink-main active:border-transparent active:text-white active:font-bold
+              disabled:bg-[#ededed] disabled:border-transparent disabled:text-black-9"
+              text={`${item}월`}
+              onClickFn={() => {
+                handleClickMonth(item);
+              }}
+              disabled={
+                todayYear > selectedYear
+                  ? true
+                  : todayYear === selectedYear
+                    ? item < todayMonth
+                    : false
+              }
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CalenderMonth;

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderWeeks.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderWeeks.tsx
@@ -1,0 +1,9 @@
+const CalenderWeeks = () => {
+  return (
+    <div>
+      <h1>월화수목금</h1>
+    </div>
+  );
+};
+
+export default CalenderWeeks;

--- a/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
@@ -1,0 +1,27 @@
+const SelectedProduct = () => {
+  return (
+    <div className="flex flex-col justify-center grow">
+      <h1 className="text-black-4 text-xs font-normal py-3 web:text-base">
+        선택된 상품
+      </h1>
+      <div className="flex">
+        <div className="w-[60px] h-[60px] mr-[14px]">
+          <img src="/assets/signupComplete.png" alt="여행 상품 메인" />
+        </div>
+        <div className="flex flex-col justify-center">
+          <div>
+            <span className="text-black-2 font-medium mr-3 web:text-lg">
+              2023.12.26
+            </span>
+            <span className="text-black-4 text-xs web:text-sm">18:28 출발</span>
+          </div>
+          <div className="text-pink-main text-lg font-semibold web:text-xl">
+            1,718,665원 (3박 4일)
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SelectedProduct;

--- a/src/app/(non-navbar)/schedule/[id]/page.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/page.tsx
@@ -1,0 +1,19 @@
+import Button from "@/app/_component/common/atom/Button";
+import DefaultHeader from "@/app/_component/common/layout/DefaultHeader";
+import Calender from "./_component/Calender";
+import SelectedProduct from "./_component/SelectedProduct";
+
+const SchedulePage = () => {
+  return (
+    <section>
+      <DefaultHeader text="여행 일정" />
+      <div className="flex flex-col h-full px-7 web:px-8">
+        <Calender />
+        <SelectedProduct />
+        <Button text="선택 완료" theme="wide" styleClass="mb-4" />
+      </div>
+    </section>
+  );
+};
+
+export default SchedulePage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "Let's",
   icons: {
-    icon: "./assets/mainLogo.svg",
+    icon: "/assets/mainLogo.svg",
   },
 };
 


### PR DESCRIPTION
## 구현 내용
- 일정 선택 페이지에서 연도와 월을 선택하는 화면 레이아웃을 추가하였습니다.
- 오늘을 기준으로 이전 달은 버튼이 비활성화 됩니다.
- 연도와 달을 기준으로 몇일인지 확인하는 기능을 추가하였습니다.

![스크린샷 2024-01-11 223420](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/e56ca612-7f6d-492b-a977-a27b2ea99fbc)

![스크린샷 2024-01-11 223403](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/ce5e5c53-0cc8-4bd5-b1cc-db23d1482964)


## 기타
- 추가한 svg파일이 이미 있는 파일일 경우 코멘트 남겨주세요!!
- 이미지만 있는 버튼은 일단 button태그를 사용하였습니다. 이후에 Button공통 컴포넌트에 기능 추가 후 교체 예정입니다.

## 이슈번호
X
