### PR TITLE
Feat: 일정 선택 날짜 선택 기능 및 기본 디자인 추가

### DIFF
--- a/public/icons/pageRightIconLight.svg
+++ b/public/icons/pageRightIconLight.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
-  <path d="M10 7.5L13.5 11L10 14.5" stroke="#666666" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M10 7.5L13.5 11L10 14.5" stroke="#DDDDDD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
   <path d="M11 21C16.523 21 21 16.523 21 11C21 5.477 16.523 1 11 1C5.477 1 1 5.477 1 11C1 16.523 5.477 21 11 21Z" stroke="#DDDDDD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/app/(non-navbar)/schedule/[id]/_component/Calender.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/Calender.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-// import CalenderDays from "./CalenderDays";
-// import CalenderWeeks from "./CalenderWeeks";
-import { useEffect, useState } from "react";
+import { getMonthInDate } from "@/utils/getMonthInDate";
+import { useState } from "react";
+import CalenderDays from "./CalenderDays";
 import CalenderHeader from "./CalenderHeader";
 import CalenderMonth from "./CalenderMonth";
+import CalenderWeeks from "./CalenderWeeks";
 
 const Calender = () => {
   const today = {
@@ -14,35 +15,42 @@ const Calender = () => {
     day: new Date().getDay(),
   };
 
+  const [selectState, setSelectState] = useState("date");
+
   const [selectedYear, setSelectedYear] = useState(today.year);
   const [selectedMonth, setSelectedMonth] = useState(today.month);
 
-  // 콘솔 확인용 제거 예정
-  // useEffect(() => {
-  //   console.log(selectedYear);
-  // }, [selectedYear]);
-
-  const monthlyDate = new Date(selectedYear, selectedMonth, 0).getDate();
-
-  // 콘솔 확인용 제거 예정
-  useEffect(() => {
-    console.log(monthlyDate);
-  }, [monthlyDate]);
+  const monthInDate = getMonthInDate(selectedYear, selectedMonth);
 
   return (
     <div>
       <CalenderHeader
+        selectState={selectState}
         selectedYear={selectedYear}
+        selectedMonth={selectedMonth}
         setSelectedYear={setSelectedYear}
-      />
-      {/* <CalenderWeeks /> */}
-      <CalenderMonth
-        todayMonth={today.month}
-        todayYear={today.year}
-        selectedYear={selectedYear}
         setSelectedMonth={setSelectedMonth}
+        setSelectState={setSelectState}
       />
-      {/* <CalenderDays /> */}
+      {selectState === "month" ? (
+        <CalenderMonth
+          todayMonth={today.month}
+          todayYear={today.year}
+          selectedYear={selectedYear}
+          setSelectedMonth={setSelectedMonth}
+          setSelectState={setSelectState}
+        />
+      ) : (
+        <>
+          <CalenderWeeks />
+          <CalenderDays
+            today={today}
+            selectedYear={selectedYear}
+            selectedMonth={selectedMonth}
+            monthInDate={monthInDate}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderDays.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderDays.tsx
@@ -1,7 +1,115 @@
-const CalenderDays = () => {
+"use client";
+
+import generateDays from "@/utils/generateDays";
+import { getMonthInDate } from "@/utils/getMonthInDate";
+import { useEffect, useState } from "react";
+
+interface Props {
+  today: Today;
+  selectedYear: number;
+  selectedMonth: number;
+  monthInDate: number;
+}
+
+interface Today {
+  year: number;
+  month: number;
+  date: number;
+  day: number;
+}
+
+const CalenderDays = ({
+  today,
+  selectedYear,
+  selectedMonth,
+  monthInDate,
+}: Props) => {
+  const prevMonthInDate = getMonthInDate(selectedYear, selectedMonth - 1);
+
+  const [days, setDays] = useState(
+    generateDays(
+      selectedYear,
+      selectedMonth,
+      monthInDate,
+      prevMonthInDate,
+      today.date,
+    ),
+  );
+
+  const isCurrent = () => {
+    return today.year === selectedYear && today.month === selectedMonth;
+  };
+
+  useEffect(() => {
+    setDays(
+      generateDays(
+        selectedYear,
+        selectedMonth,
+        monthInDate,
+        prevMonthInDate,
+        today.date,
+      ),
+    );
+  }, [selectedYear, selectedMonth, monthInDate, prevMonthInDate, today.date]);
+
+  const getDateColor = (
+    type: string | null,
+    isCurrentMonth: boolean,
+    dayItem: number | null,
+  ) => {
+    if (!isCurrentMonth) {
+      if (type === "sat") return "text-[#BBD1ED]";
+      if (type === "sun") return "text-[#FCC]";
+      return "text-grey-d";
+    }
+
+    if (type === "sat") {
+      return (dayItem as number) < today.date && isCurrent()
+        ? "text-[#BBD1ED]"
+        : "text-[#4B8CDD]";
+    }
+
+    if (type === "sun") {
+      return (dayItem as number) < today.date && isCurrent()
+        ? "text-[#FCC]"
+        : "text-[#E44C4B]";
+    }
+
+    if (type === "cur" && isCurrent()) return "text-[#71DD4B]";
+
+    if (type === null && isCurrent() && today.date > (dayItem as number)) {
+      return "text-grey-d";
+    }
+
+    return "";
+  };
+
   return (
     <div>
-      <h1>일일일일</h1>
+      {days.map((week) => {
+        return (
+          <div
+            key={week.weekId}
+            className="flex justify-between text-black-2 text-sm font-medium mt-6 web:text-base web:mt-5"
+          >
+            {week.weekItem.map((day) => {
+              return (
+                <button
+                  type="button"
+                  key={day.dayId}
+                  className={`w-[30px] h-[30px] flex justify-center items-center ${getDateColor(
+                    day.type,
+                    day.isCurrentMonth,
+                    day.dayItem,
+                  )}`}
+                >
+                  {day.dayItem}
+                </button>
+              );
+            })}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderHeader.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderHeader.tsx
@@ -1,36 +1,95 @@
 "use client";
 
+import Button from "@/app/_component/common/atom/Button";
+
 interface Props {
+  selectState: string;
   selectedYear: number;
+  selectedMonth: number;
   setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
+  setSelectedMonth: React.Dispatch<React.SetStateAction<number>>;
+  setSelectState: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const CalenderHeader = ({ selectedYear, setSelectedYear }: Props) => {
+const JANUARY = 1;
+const DECEMBER = 12;
+
+const CalenderHeader = ({
+  selectState,
+  selectedYear,
+  selectedMonth,
+  setSelectedYear,
+  setSelectedMonth,
+  setSelectState,
+}: Props) => {
   const handleClickPrevYear = () => {
-    setSelectedYear((prev) => prev - 1);
+    if (selectState === "month") {
+      setSelectedYear((prev) => prev - 1);
+    } else {
+      setSelectedMonth((prev) => prev - 1);
+    }
   };
   const handleClickNextYear = () => {
-    setSelectedYear((prev) => prev + 1);
+    if (selectState === "month") {
+      setSelectedYear((prev) => prev + 1);
+    } else {
+      setSelectedMonth((prev) => prev + 1);
+    }
+  };
+
+  const handleHeaderClick = () => {
+    if (selectState === "date") setSelectState("month");
   };
 
   return (
     <div className="flex items-center justify-between h-10 mt-9 web:mt-5">
-      <button type="button" onClick={handleClickPrevYear}>
-        <img
-          src="/icons/pageLeftIcon.svg"
-          alt="이전"
-          className="w-5 h-5 web:w-7 web:h-7"
-        />
+      <button
+        type="button"
+        onClick={handleClickPrevYear}
+        disabled={selectState === "date" && selectedMonth === JANUARY}
+      >
+        {selectState === "date" && selectedMonth === JANUARY ? (
+          <img
+            src="/icons/pageLeftIconLight.svg"
+            alt="이전"
+            className="w-5 h-5 web:w-7 web:h-7"
+          />
+        ) : (
+          <img
+            src="/icons/pageLeftIcon.svg"
+            alt="이전"
+            className="w-5 h-5 web:w-7 web:h-7"
+          />
+        )}
       </button>
-      <h1 className="text-base text-black-2 font-medium web:text-xl">
-        {selectedYear}
-      </h1>
-      <button type="button" onClick={handleClickNextYear}>
-        <img
-          src="/icons/pageRightIcon.svg"
-          alt="다음"
-          className="w-5 h-5 web:w-7 web:h-7"
-        />
+      <Button
+        text={
+          selectState === "month"
+            ? selectedYear.toString()
+            : `${selectedYear}.${selectedMonth}`
+        }
+        styleClass="text-base text-black-2 font-medium web:text-xl"
+        onClickFn={handleHeaderClick}
+      />
+
+      <button
+        type="button"
+        onClick={handleClickNextYear}
+        disabled={selectState === "date" && selectedMonth === DECEMBER}
+      >
+        {selectState === "date" && selectedMonth === DECEMBER ? (
+          <img
+            src="/icons/pageRightIconLight.svg"
+            alt="이전"
+            className="w-5 h-5 web:w-7 web:h-7"
+          />
+        ) : (
+          <img
+            src="/icons/pageRightIcon.svg"
+            alt="이전"
+            className="w-5 h-5 web:w-7 web:h-7"
+          />
+        )}
       </button>
     </div>
   );

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderMonth.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderMonth.tsx
@@ -11,7 +11,7 @@ interface Props {
 const NUMBER_IN_ONE_LINE = 3;
 const MONTH_LIST = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 const CENTER_ITEM = 1;
-const LAST_ITEM = 1;
+const LAST_ITEM = 2;
 
 const CalenderMonth = ({
   todayYear,

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderMonth.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderMonth.tsx
@@ -5,28 +5,38 @@ interface Props {
   todayMonth: number;
   selectedYear: number;
   setSelectedMonth: React.Dispatch<React.SetStateAction<number>>;
+  setSelectState: React.Dispatch<React.SetStateAction<string>>;
 }
+
+const NUMBER_IN_ONE_LINE = 3;
+const MONTH_LIST = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+const CENTER_ITEM = 1;
+const LAST_ITEM = 1;
 
 const CalenderMonth = ({
   todayYear,
   todayMonth,
   selectedYear,
   setSelectedMonth,
+  setSelectState,
 }: Props) => {
-  const Month = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-
-  const handleClickMonth = (month: number) => {
-    setSelectedMonth(month);
+  const handleClickMonth = (select: number) => {
+    setSelectedMonth(select);
+    setSelectState("date");
   };
 
   return (
     <div className="flex flex-wrap mt-3 web:mt-5">
-      {Month.map((item, index) => {
+      {MONTH_LIST.map((item, index) => {
         return (
           <div
             key={item}
-            className={`flex justify-${
-              index % 3 === 1 ? "center" : index % 3 === 2 ? "end" : "start"
+            className={`flex ${
+              index % NUMBER_IN_ONE_LINE === CENTER_ITEM
+                ? "justify-center"
+                : index % NUMBER_IN_ONE_LINE === LAST_ITEM
+                  ? "justify-end"
+                  : "justify-start"
             } items-center w-1/3 mb-3 web:w-1/4 web:justify-center`}
           >
             <Button

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderWeeks.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderWeeks.tsx
@@ -1,7 +1,26 @@
+const DAY_LIST = [
+  { id: 1, name: "일" },
+  { id: 2, name: "월" },
+  { id: 3, name: "화" },
+  { id: 4, name: "수" },
+  { id: 5, name: "목" },
+  { id: 6, name: "금" },
+  { id: 7, name: "토" },
+];
+
 const CalenderWeeks = () => {
   return (
-    <div>
-      <h1>월화수목금</h1>
+    <div className="flex justify-between mt-9 web:mt-6">
+      {DAY_LIST.map((day) => {
+        return (
+          <div
+            key={day.id}
+            className="w-[30px] h-[30px] flex justify-center items-center text-sm text-black-4 web:text-lg"
+          >
+            {day.name}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
@@ -1,7 +1,7 @@
 const SelectedProduct = () => {
   return (
-    <div className="flex flex-col justify-center grow">
-      <h1 className="text-black-4 text-xs font-normal py-3 web:text-base">
+    <div className="flex flex-col justify-center grow mt-6 web:mt-3">
+      <h1 className="text-black-4 text-xs font-normal py-1 web:text-base">
         선택된 상품
       </h1>
       <div className="flex">

--- a/src/utils/generateDays.ts
+++ b/src/utils/generateDays.ts
@@ -1,0 +1,92 @@
+import { getFirstDayInMonth } from "./getMonthInDate";
+
+interface Day {
+  dayId: number;
+  dayItem: null | number;
+  isCurrentMonth: boolean;
+  type: "sat" | "sun" | "cur" | null;
+}
+
+interface Week {
+  weekId: number;
+  weekItem: Day[];
+}
+
+const VIEW_WEEK_LENGTH = 6;
+const VIEW_DAY_LENGTH = 7;
+const SUNDAY_NUMBER = 0;
+const SATURDAY_NUMBER = 6;
+
+const addAnotherMonth = (
+  days: Week[],
+  firstDay: number,
+  prevMonthInDate: number,
+) => {
+  let prevStart = prevMonthInDate - firstDay + 1;
+  days.forEach((day) => {
+    day.weekItem.forEach((item) => {
+      if (item.dayItem === null) {
+        item.dayItem = prevStart;
+        item.isCurrentMonth = false;
+        prevStart += 1;
+      } else {
+        prevStart = 1;
+      }
+    });
+  });
+
+  return days;
+};
+
+const generateDays = (
+  year: number,
+  month: number,
+  daysInMonth: number,
+  prevMonthInDate: number,
+  today: number,
+) => {
+  const firstDayInLastMonth = getFirstDayInMonth(year, month - 1);
+  let weekId = 1;
+  let daysId = 1;
+
+  const days = [];
+
+  let count = 1;
+
+  for (let i = 0; i < VIEW_WEEK_LENGTH; i += 1) {
+    const week: Week = {
+      weekId: weekId,
+      weekItem: [],
+    };
+    for (let j = 0; j < VIEW_DAY_LENGTH; j += 1) {
+      const day: Day = {
+        dayId: daysId,
+        dayItem: null,
+        isCurrentMonth: true,
+        type:
+          j === SUNDAY_NUMBER
+            ? "sun"
+            : j === SATURDAY_NUMBER
+              ? "sat"
+              : count === today
+                ? "cur"
+                : null,
+      };
+      if ((i === 0 && j < firstDayInLastMonth) || count > daysInMonth) {
+        day.dayItem = null;
+        week.weekItem.push(day);
+      } else {
+        day.dayItem = count;
+        week.weekItem.push(day);
+        count += 1;
+      }
+      daysId += 1;
+    }
+    days.push(week);
+    weekId += 1;
+  }
+
+  return addAnotherMonth(days, firstDayInLastMonth, prevMonthInDate);
+};
+
+export default generateDays;

--- a/src/utils/getMonthInDate.ts
+++ b/src/utils/getMonthInDate.ts
@@ -1,0 +1,17 @@
+const PREV_MONTH_LAST_DAY = 0;
+const CURRNET_MONTH_FIRST_DAY = 1;
+
+export const getMonthInDate = (selectedYear: number, selectedMonth: number) => {
+  return new Date(selectedYear, selectedMonth, PREV_MONTH_LAST_DAY).getDate();
+};
+
+export const getFirstDayInMonth = (
+  selectedYear: number,
+  selectedMonth: number,
+) => {
+  return new Date(
+    selectedYear,
+    selectedMonth,
+    CURRNET_MONTH_FIRST_DAY,
+  ).getDay();
+};


### PR DESCRIPTION
## 구현 내용
- 선택한 연도와 월에 따라서 화면에 캘린더가 표시되도록 기능을 추가하였습니다.
- 요일, 현재 날짜에 따라서 캘린더 숫자의 색상이 다르게 표시되도록 기능을 추가하였습니다.

웹
![schedule](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/83220a38-f96b-4ee3-8d3d-eded9a91cb94)
모바일
![스크린샷 2024-01-12 215026](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/21ec6d5e-d2f5-47a1-a4d5-f2ebb627eae1)

![스크린샷 2024-01-12 215020](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/97152fe0-55a4-4656-a52c-38a800254834)


## 기타
- 캘린더 구현이 예상보다 코드가 길어져 중간 pr한번 올립니다. 
- 이후에 해당 브랜치에서 캘린더 관련 기본 레이아웃, 기능 작업을 이어갈 예정입니다.
- 이후 스타일 색상도 tailwind 설정에 추가 예정입니다.

## 이슈번호
X
