### PR TITLE
Feat: 캘린더 상품 데이터 MSW연결

### DIFF
--- a/src/api/items/getPackageDetail.ts
+++ b/src/api/items/getPackageDetail.ts
@@ -1,0 +1,19 @@
+const getPackageDetail = async (id: number, query?: string | null) => {
+  let url;
+  if (query) {
+    url = `${process.env.NEXT_PUBLIC_BASE_URL}/v1/packages/${id}?departDate=${query}`;
+  } else {
+    url = `${process.env.NEXT_PUBLIC_BASE_URL}/v1/packages/${id}`;
+  }
+  const result = await fetch(url, {
+    cache: "no-store",
+  });
+
+  if (!result.ok) {
+    throw new Error("Failed to fetch data");
+  }
+
+  return result.json();
+};
+
+export default getPackageDetail;

--- a/src/api/schedule/getAvailableDates.ts
+++ b/src/api/schedule/getAvailableDates.ts
@@ -1,0 +1,16 @@
+const getAvailableDates = async (id: number) => {
+  const result = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/v1/packages/${id}/available-dates`,
+    {
+      cache: "no-store",
+    },
+  );
+
+  if (!result.ok) {
+    throw new Error("Failed to fetch data");
+  }
+
+  return result.json();
+};
+
+export default getAvailableDates;

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderHeader.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderHeader.tsx
@@ -42,7 +42,7 @@ const CalenderHeader = ({
   };
 
   return (
-    <div className="flex items-center justify-between h-10 mt-9 web:mt-5">
+    <div className="flex items-center justify-between h-10 mt-2">
       <button
         type="button"
         onClick={handleClickPrevYear}

--- a/src/app/(non-navbar)/schedule/[id]/_component/CalenderWeeks.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/CalenderWeeks.tsx
@@ -10,7 +10,7 @@ const DAY_LIST = [
 
 const CalenderWeeks = () => {
   return (
-    <div className="flex justify-between h-12 mt-9 web:mt-4">
+    <div className="flex justify-between h-12 mt-3">
       {DAY_LIST.map((day) => {
         return (
           <div

--- a/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
@@ -6,11 +6,24 @@ const SelectedProduct = () => {
   const scheduleDate = useScheduleDateStore();
 
   if (scheduleDate.data === null) {
-    return "";
+    return (
+      <div className="flex flex-col justify-end grow -translate-y-16 web:-translate-y-11">
+        <h1 className="text-black-4 text-xs font-normal py-1 web:text-base">
+          선택된 상품
+        </h1>
+        <div className="flex animate-pulse">
+          <div className="w-[60px] h-[60px] mr-[14px] bg-grey-d rounded-md" />
+          <div className="flex flex-col justify-center">
+            <div className="w-[180px] h-[25px] bg-grey-d rounded-md mb-1" />
+            <div className="w-[180px] h-[25px] bg-grey-d rounded-md" />
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div className="flex flex-col justify-end grow -translate-y-12 web:-translate-y-9">
+    <div className="flex flex-col justify-end grow -translate-y-16 web:-translate-y-11">
       <h1 className="text-black-4 text-xs font-normal py-1 web:text-base">
         선택된 상품
       </h1>

--- a/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
@@ -5,6 +5,10 @@ import useScheduleDateStore from "@/store/useScheduleDateStore";
 const SelectedProduct = () => {
   const scheduleDate = useScheduleDateStore();
 
+  const formatSelectedItemDate = (date: string) => {
+    return date.replace(/-/g, ".");
+  };
+
   if (scheduleDate.data === null) {
     return (
       <div className="flex flex-col justify-end grow -translate-y-16 web:-translate-y-11">
@@ -15,7 +19,7 @@ const SelectedProduct = () => {
           <div className="w-[60px] h-[60px] mr-[14px] bg-grey-d rounded-md" />
           <div className="flex flex-col justify-center">
             <div className="w-[180px] h-[25px] bg-grey-d rounded-md mb-1" />
-            <div className="w-[180px] h-[25px] bg-grey-d rounded-md" />
+            <div className="w-[190px] h-[25px] bg-grey-d rounded-md" />
           </div>
         </div>
       </div>
@@ -34,12 +38,15 @@ const SelectedProduct = () => {
         <div className="flex flex-col justify-center">
           <div>
             <span className="text-black-2 font-medium mr-3 web:text-lg">
-              2023.12.26
+              {formatSelectedItemDate(scheduleDate.data.departureDatetime.date)}
             </span>
-            <span className="text-black-4 text-xs web:text-sm">18:28 출발</span>
+            <span className="text-black-4 text-xs web:text-sm">
+              {scheduleDate.data.departureDatetime.time} 출발
+            </span>
           </div>
           <div className="text-pink-main text-lg font-semibold web:text-xl">
-            {scheduleDate.data.totalPrice.adult.toLocaleString()}원 (3박 4일)
+            {scheduleDate.data.totalPrice.adult.toLocaleString()}원 (
+            {scheduleDate.data.lodgeDays}박 {scheduleDate.data.tripDays}일)
           </div>
         </div>
       </div>

--- a/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
@@ -1,4 +1,14 @@
+"use client";
+
+import useScheduleDateStore from "@/store/useScheduleDateStore";
+
 const SelectedProduct = () => {
+  const scheduleDate = useScheduleDateStore();
+
+  if (scheduleDate.data === null) {
+    return "";
+  }
+
   return (
     <div className="flex flex-col justify-end grow -translate-y-12 web:-translate-y-9">
       <h1 className="text-black-4 text-xs font-normal py-1 web:text-base">
@@ -16,7 +26,7 @@ const SelectedProduct = () => {
             <span className="text-black-4 text-xs web:text-sm">18:28 출발</span>
           </div>
           <div className="text-pink-main text-lg font-semibold web:text-xl">
-            1,718,665원 (3박 4일)
+            {scheduleDate.data.totalPrice.adult.toLocaleString()}원 (3박 4일)
           </div>
         </div>
       </div>

--- a/src/app/(non-navbar)/schedule/[id]/page.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/page.tsx
@@ -37,7 +37,7 @@ const SchedulePage = async ({ params }: { params: { id: string } }) => {
         <Button
           text="선택 완료"
           theme="wide"
-          styleClass="-translate-y-3 web:-translate-y-3"
+          styleClass="-translate-y-12 web:-translate-y-5"
         />
       </div>
     </section>

--- a/src/app/(non-navbar)/schedule/[id]/page.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/page.tsx
@@ -1,14 +1,38 @@
+import getPackageDetail from "@/api/items/getPackageDetail";
+import getAvailableDates from "@/api/schedule/getAvailableDates";
 import Button from "@/app/_component/common/atom/Button";
 import DefaultHeader from "@/app/_component/common/layout/DefaultHeader";
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from "@tanstack/react-query";
 import Calender from "./_component/Calender";
 import SelectedProduct from "./_component/SelectedProduct";
 
-const SchedulePage = () => {
+const SchedulePage = async ({ params }: { params: { id: string } }) => {
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["schedule-date", params.id],
+    queryFn: async () => {
+      return getAvailableDates(Number(params.id));
+    },
+  });
+  await queryClient.prefetchQuery({
+    queryKey: ["package-detail", params.id],
+    queryFn: async () => {
+      return getPackageDetail(Number(params.id));
+    },
+  });
+  const dehydrateState = dehydrate(queryClient);
+
   return (
     <section>
       <DefaultHeader text="여행 일정" />
       <div className="flex flex-col h-full px-7 web:px-8">
-        <Calender />
+        <HydrationBoundary state={dehydrateState}>
+          <Calender />
+        </HydrationBoundary>
         <SelectedProduct />
         <Button
           text="선택 완료"

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -34,3 +34,56 @@ export interface ScheduleResponseData {
   code: number;
   data: DateInfo[];
 }
+
+// items
+
+export interface DateTime {
+  date: string;
+  dayOfWeek: string;
+  time: string;
+}
+
+export interface Price {
+  adult: number;
+  infant: number;
+  baby: number;
+}
+
+export interface Reservation {
+  current: number;
+  remain: number;
+  min: number;
+}
+
+export interface InclusionExclusion {
+  title: string;
+  description: string;
+}
+
+export interface PackageResponseData {
+  packageId: number;
+  hashtags: string[];
+  departureDatetime: DateTime;
+  endDatetime: DateTime;
+  imageUrls: string[];
+  nationName: string;
+  continentName: string;
+  title: string;
+  averageStars: number;
+  totalPrice: Price;
+  reservation: Reservation;
+  transporation: string;
+  info: string[];
+  introImageUrls: string[];
+  inclusionList: InclusionExclusion[];
+  exclusionList: InclusionExclusion[];
+  lodgeDays: number;
+  tripDays: number;
+  reviewCount: number;
+  myInfo: {
+    username: string;
+    email: string;
+    phone: string;
+  };
+  isWish: boolean;
+}

--- a/src/mocks/data/packageScheduleData.ts
+++ b/src/mocks/data/packageScheduleData.ts
@@ -3,43 +3,22 @@ export const availableResponseData = {
   data: [
     {
       availableDateId: 0,
-      date: "2024-01-20",
+      date: "2024-01-23",
       adultPrice: 300000,
       lodgeDays: 1,
       tripDays: 2,
     },
     {
       availableDateId: 0,
-      date: "2024-01-21",
+      date: "2024-01-24",
       adultPrice: 210000,
       lodgeDays: 1,
       tripDays: 2,
     },
     {
       availableDateId: 0,
-      date: "2024-01-22",
-      adultPrice: 1000000,
-      lodgeDays: 1,
-      tripDays: 2,
-    },
-    {
-      availableDateId: 0,
-      date: "2024-01-23",
-      adultPrice: 100000,
-      lodgeDays: 1,
-      tripDays: 2,
-    },
-    {
-      availableDateId: 0,
-      date: "2024-01-24",
-      adultPrice: 500000,
-      lodgeDays: 1,
-      tripDays: 2,
-    },
-    {
-      availableDateId: 0,
       date: "2024-01-25",
-      adultPrice: 100000,
+      adultPrice: 1000000,
       lodgeDays: 1,
       tripDays: 2,
     },
@@ -53,7 +32,7 @@ export const availableResponseData = {
     {
       availableDateId: 0,
       date: "2024-01-27",
-      adultPrice: 300000,
+      adultPrice: 500000,
       lodgeDays: 1,
       tripDays: 2,
     },
@@ -67,56 +46,56 @@ export const availableResponseData = {
     {
       availableDateId: 0,
       date: "2024-01-29",
-      adultPrice: 1230000,
-      lodgeDays: 1,
-      tripDays: 2,
-    },
-    {
-      availableDateId: 0,
-      date: "2024-01-30",
-      adultPrice: 2100000,
-      lodgeDays: 1,
-      tripDays: 2,
-    },
-    {
-      availableDateId: 0,
-      date: "2024-01-31",
-      adultPrice: 2230000,
-      lodgeDays: 1,
-      tripDays: 2,
-    },
-    {
-      availableDateId: 0,
-      date: "2024-02-01",
-      adultPrice: 500000,
-      lodgeDays: 1,
-      tripDays: 2,
-    },
-    {
-      availableDateId: 0,
-      date: "2024-02-02",
-      adultPrice: 520000,
-      lodgeDays: 1,
-      tripDays: 2,
-    },
-    {
-      availableDateId: 0,
-      date: "2024-02-03",
       adultPrice: 100000,
       lodgeDays: 1,
       tripDays: 2,
     },
     {
       availableDateId: 0,
-      date: "2024-02-04",
+      date: "2024-01-30",
+      adultPrice: 300000,
+      lodgeDays: 1,
+      tripDays: 2,
+    },
+    {
+      availableDateId: 0,
+      date: "2024-01-31",
+      adultPrice: 100000,
+      lodgeDays: 1,
+      tripDays: 2,
+    },
+    {
+      availableDateId: 0,
+      date: "2024-02-01",
+      adultPrice: 1230000,
+      lodgeDays: 1,
+      tripDays: 2,
+    },
+    {
+      availableDateId: 0,
+      date: "2024-02-02",
       adultPrice: 2100000,
       lodgeDays: 1,
       tripDays: 2,
     },
     {
       availableDateId: 0,
+      date: "2024-02-03",
+      adultPrice: 2230000,
+      lodgeDays: 1,
+      tripDays: 2,
+    },
+    {
+      availableDateId: 0,
+      date: "2024-02-04",
+      adultPrice: 500000,
+      lodgeDays: 1,
+      tripDays: 2,
+    },
+    {
+      availableDateId: 0,
       date: "2024-02-05",
-      adultPrice: 1130000,
+      adultPrice: 520000,
       lodgeDays: 1,
       tripDays: 2,
     },
@@ -127,42 +106,67 @@ export const availableResponseData = {
       lodgeDays: 1,
       tripDays: 2,
     },
+    {
+      availableDateId: 0,
+      date: "2024-02-07",
+      adultPrice: 2100000,
+      lodgeDays: 1,
+      tripDays: 2,
+    },
+    {
+      availableDateId: 0,
+      date: "2024-02-08",
+      adultPrice: 1130000,
+      lodgeDays: 1,
+      tripDays: 2,
+    },
+    {
+      availableDateId: 0,
+      date: "2024-02-09",
+      adultPrice: 100000,
+      lodgeDays: 1,
+      tripDays: 2,
+    },
   ],
 };
 
-export const packageDetail = {
-  code: 200,
-  data: {
-    packageId: 0,
-    hashtags: [""],
+export const details = [
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
     departureDatetime: {
-      date: "2010-01-01",
+      date: "2024-01-23",
       dayOfWeek: "월",
       time: "11:20",
     },
     endDatetime: {
-      date: "2010-01-01",
+      date: "2024-01-27",
       dayOfWeek: "월",
       time: "11:20",
     },
-    imageUrls: [""],
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
     nationName: "나라 이름",
     continentName: "대륙 이름",
-    title: "제목",
-    averageStars: 0.0, // (0.0~10.0)
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
     totalPrice: {
-      adult: 0, // 성인 (0일 경우 없음)
-      infant: 0, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
-      baby: 0, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+      adult: 300000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
     },
     reservation: {
-      current: 0, // 예약자 수
-      remain: 0, // 잔여 예약 가능 수
-      min: 0, // 최소 출발 인원
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
     },
     transporation: "티웨이항공 직항",
     info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
-    introImageUrls: [""], // 상품 소개 이미지
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
     inclusionList: [
       { title: "제세공과금", description: "" },
       { title: "식사", description: "일정표 상 식사" },
@@ -181,4 +185,922 @@ export const packageDetail = {
     },
     isWish: false, // 비로그인 시에는 항상 false
   },
-};
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-01-24",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 210000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-01-25",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 1000000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-01-26",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 100000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 500000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-01-28",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 100000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-01-29",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 100000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-01-30",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 300000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-01-31",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 100000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-01",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 1230000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-02",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 2100000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-03",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 2230000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-04",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 500000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-05",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 520000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-06",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 100000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-07",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 2100000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-08",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 1130000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+  {
+    packageId: 3,
+    hashtags: ["테마파크", "액티비티", "체험"],
+    departureDatetime: {
+      date: "2024-02-09",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    endDatetime: {
+      date: "2024-01-27",
+      dayOfWeek: "월",
+      time: "11:20",
+    },
+    imageUrls: [
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    ],
+    nationName: "나라 이름",
+    continentName: "대륙 이름",
+    title:
+      "[W가족] 오사카 3일, 1일 자유시간+교토 or 유니버셜스튜디오 선택 관광",
+    averageStars: 4.3, // (0.0~10.0)
+    totalPrice: {
+      adult: 100000, // 성인 (0일 경우 없음)
+      infant: 100000, // 소아 (0일 경우 '문의 요망'으로 표시해야 함)
+      baby: 100000, // 유아 (0일 경우 '문의 요망'으로 표시해야 함)
+    },
+    reservation: {
+      current: 3, // 예약자 수
+      remain: 3, // 잔여 예약 가능 수
+      min: 3, // 최소 출발 인원
+    },
+    transporation: "티웨이항공 직항",
+    info: ["패키지", "항공", "1박 2일", "현지경비 KRW 1,000"],
+    introImageUrls: [
+      "https://media.interparkcdn.net/interpark-tour/f_jpg/q_auto/tourimage/BBS/Tour/FckUpload/202311/638363515419949726.png",
+    ], // 상품 소개 이미지
+    inclusionList: [
+      { title: "제세공과금", description: "" },
+      { title: "식사", description: "일정표 상 식사" },
+    ],
+    exclusionList: [
+      { title: "선택관광비용", description: "" },
+      { title: "자유일정 시 식사", description: "일정표 참고" },
+    ],
+    lodgeDays: 1, // 1박
+    tripDays: 2, // 2일
+    reviewCount: 0,
+    myInfo: {
+      username: "",
+      email: "",
+      phone: "",
+    },
+    isWish: false, // 비로그인 시에는 항상 false
+  },
+];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { availableResponseData, details } from "./data/packageScheduleData";
 
 const handlers = [
   http.get("/api/hi", () => {
@@ -6,6 +7,7 @@ const handlers = [
     return HttpResponse.json("hi");
   }),
 
+  // 로그인 회원가입
   http.post("/v1/users/email/confirm", () => {
     console.log("인증번호 요청");
     return HttpResponse.json({
@@ -63,6 +65,13 @@ const handlers = [
         },
       },
     );
+  }),
+
+  // 일정 예약
+  http.get("/v1/packages/:id/available-dates", () => {
+    console.log("가능한 일정 조회");
+
+    return HttpResponse.json(availableResponseData);
   }),
 
   http.get("/v1/search/hashtags", () => {
@@ -214,6 +223,27 @@ const handlers = [
       code: 200,
       data: packagesList,
       page: pages,
+    });
+  }),
+
+  // 패키지 상세
+  http.get("/v1/packages/:id", ({ request }) => {
+    console.log("패키지 상세 조회");
+    const url = new URL(request.url);
+    const departDate = url.searchParams.get("departDate");
+    let newData;
+    if (departDate) {
+      const foundData = details.find(
+        (detail) => detail.departureDatetime.date === departDate,
+      );
+      newData = foundData || null;
+    } else {
+      newData = details[0] || null;
+    }
+
+    return HttpResponse.json({
+      code: 200,
+      data: newData,
     });
   }),
 ];

--- a/src/store/useScheduleDateStore.ts
+++ b/src/store/useScheduleDateStore.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+import { PackageResponseData } from "@/app/types";
+
+interface Props {
+  date: string | null;
+  data: PackageResponseData | null;
+  updateDate: (date: string) => void;
+  updateData: (data: PackageResponseData) => void;
+}
+
+const useScheduleDateStore = create<Props>((set) => ({
+  date: null,
+  data: null,
+  updateDate: (date) => set(() => ({ date })),
+  updateData: (data) => set(() => ({ data })),
+}));
+
+export default useScheduleDateStore;


### PR DESCRIPTION
## 구현 내용
- 캘린더의 동작이 MSW서버의 요청에 따라서 동작하도록 기능을  추가하였습니다.
- 상품의 데이터를 연결하였습니다.
- 초기 진입 시 선택된 상품의 스켈레톤 UI를 추가하였습니다.
- 패키지 스케줄 표시를 위한 데이터를 추가했습니다. (이후 제거 예정)
![스크린샷 2024-01-14 201920](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/2cd8026d-b4c3-41c6-9890-1e57dc96aeea)

## 기타
- 스케줄 가짜 데이터의 추가로 코드가 길어 보일 수 있습니다.
- type.ts 폴더를 변경하였습니다.
- handlers.ts 폴더를 변경하였습니다.

## 이슈번호
연결된 이슈가 있을 때만 작성해 주세요!
