### PR TITLE
Feature: 메인 페이지 레이아웃 수정 / 해시태그 버튼 디자인 수정

### DIFF
--- a/src/app/_component/common/layout/DefaultHeader.tsx
+++ b/src/app/_component/common/layout/DefaultHeader.tsx
@@ -26,23 +26,38 @@ const DefaultHeader = ({
 
   return (
     <div className="flex relative w-full h-[48px]">
-      {redirectUrl ? (
-        <Link
-          href={redirectUrl}
-          className="absolute left-[32px] top-1/2 -translate-y-1/2"
-        >
-          <img src="/icons/leftArrowIcon.svg" alt="왼쪽 화살표" width="24px" />
-        </Link>
-      ) : (
-        <div
-          className="absolute left-[32px] top-1/2 -translate-y-1/2"
-          onClick={() => {
-            router.back();
-          }}
-        >
-          <img src="/icons/leftArrowIcon.svg" alt="왼쪽 화살표" width="24px" />
-        </div>
-      )}
+      {/* 
+      메인 페이지인지를 판단하기 위한 외부 삼항 연산자
+      넘겨받은 theme 값이 default인 경우, 내부 삼항 연산자 로직으로
+      default가 아닌 경우(메인 페이지), null을 반환해 화살표 노출하지 않음
+      */}
+      {theme === "default" ? (
+        redirectUrl ? (
+          <Link
+            href={redirectUrl}
+            className="absolute left-[32px] top-1/2 -translate-y-1/2"
+          >
+            <img
+              src="/icons/leftArrowIcon.svg"
+              alt="왼쪽 화살표"
+              width="24px"
+            />
+          </Link>
+        ) : (
+          <div
+            className="absolute left-[32px] top-1/2 -translate-y-1/2"
+            onClick={() => {
+              router.back();
+            }}
+          >
+            <img
+              src="/icons/leftArrowIcon.svg"
+              alt="왼쪽 화살표"
+              width="24px"
+            />
+          </div>
+        )
+      ) : null}
 
       <div className="absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2 text-[18px] text-black-2 font-semibold">
         {theme === "default" && (

--- a/src/app/_component/home/HomeHashtags.tsx
+++ b/src/app/_component/home/HomeHashtags.tsx
@@ -4,10 +4,10 @@ import Button from "@/app/_component/common/atom/Button";
 
 const HomeHashtags = () => {
   return (
-    <div className="w-[90%]">
+    <div className="w-[100%]">
       <Button
         text="3초만에 내가 원하는 여행 찾기 >"
-        styleClass="w-full h-[56px] p-4 hover:bg-[#bb1e4a] bg-pink text-white text-left tracking-widest rounded-lg"
+        styleClass="w-[327px] web:w-[100%] h-[64px] pl-5 py-5 hover:bg-[#bb1e4a] bg-pink text-white text-left tracking-widest rounded-lg"
       />
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,22 +8,26 @@ import HomeThemePackage from "./_component/home/HomeThemePackage";
 
 const Home = async () => {
   return (
-    <section className="web:w-[500px] mx-auto">
-      <DefaultHeader text="/" theme="main" />
-      <div className="w-[327px] web:w-[90%] flex flex-col items-center [&>*:nth-child(n)]:mb-10 mx-auto">
-        {/* 광고구좌 */}
-        <HomeAdvertisements />
-        {/* 해시태그 검색 */}
-        <HomeHashtags />
-        {/* 패키지 컨셉 */}
-        <HomeThemePackage />
-        {/* 찬반토론 */}
-        <HomeProsAndCons />
-        {/* 초특가 패키지 목록 */}
-        <HomePackages />
-      </div>
+    <>
+      <main>
+        <section className="w-full flex flex-col items-center">
+          <DefaultHeader text="/" theme="main" />
+          <div className="w-[327px] web:w-[90%] [&>*:nth-child(n)]:mb-10">
+            {/* 광고구좌 */}
+            <HomeAdvertisements />
+            {/* 해시태그 검색 */}
+            <HomeHashtags />
+            {/* 패키지 컨셉 */}
+            <HomeThemePackage />
+            {/* 찬반토론 */}
+            <HomeProsAndCons />
+            {/* 초특가 패키지 목록 */}
+            <HomePackages />
+          </div>
+        </section>
+      </main>
       <BottomNav />
-    </section>
+    </>
   );
 };
 


### PR DESCRIPTION
## 구현 내용
- 메인 페이지에서 헤더 좌측에 기타 페이지처럼 화살표가 생성되고, 온클릭 메서드를 통해 뒤로 가기 동작이 이루어지던 부분을 수정했습니다.
  - 기존 `redirectUrl ? ... : ... `와 같이 redirectUrl로의 이동인지, 혹은 router.back() 메서드를 통한 뒤로 가기 이동인지 구분하던 삼항연산자 로직을 감싸는 새로운 삼항연산자 로직을 작성했습니다.
  - true 조건은 넘겨받은 theme이 default일 때이며, theme이 main인 경우에는 false 조건으로 null을 반환하고, 화살표가 노출되지 않게 합니다.

- 메인 페이지에서 하단 네비게이션 바의 위치가 부자연스럽고 375 x 812 모바일 뷰를 벗어난 경우, 하단 네비게이션 바가 우측으로 밀려나던 현상을 수정했습니다.
  - 기존 `<section>` 태그 안에서 요소를 가운데 정렬하기 위해 사용했던 `mx-auto` 코드가 원인이었습니다. 
  - `(navbar) > layout.tsx` 의 디자인을 참고해 수정하였습니다!

## 기타
<img width="872" alt="스크린샷 2024-01-15 오후 1 26 45" src="https://github.com/yanolja-finalproject/LETS_FE/assets/62874043/3aef9690-a2e9-4e1b-bb3e-c64b1c529a7e">


## 이슈번호
X