### PR TITLE
Feat: 상세페이지 이미지 캐러셀 추가, 데이터 MSW연결

### DIFF
--- a/src/app/(non-navbar)/items/[id]/_component/DetailBottomButton.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailBottomButton.tsx
@@ -6,12 +6,12 @@ const DetailBottomButton = () => {
       className={`flex justify-between items-center w-full h-20 px-6 py-5 web:h-24`}
     >
       <Button
-        text="asd"
+        text="1:1 비교하기"
         theme="wide"
         styleClass="h-[40px] w-[151px] web:h-[50px] web:w-[215px]"
       />
       <Button
-        text="asd"
+        text="예약하기"
         theme="wide"
         styleClass="h-[40px] w-[151px] web:h-[50px] web:w-[215px]"
       />

--- a/src/app/(non-navbar)/items/[id]/_component/DetailBottomButton.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailBottomButton.tsx
@@ -1,0 +1,22 @@
+import Button from "@/app/_component/common/atom/Button";
+
+const DetailBottomButton = () => {
+  return (
+    <nav
+      className={`flex justify-between items-center w-full h-20 px-6 py-5 web:h-24`}
+    >
+      <Button
+        text="asd"
+        theme="wide"
+        styleClass="h-[40px] w-[151px] web:h-[50px] web:w-[215px]"
+      />
+      <Button
+        text="asd"
+        theme="wide"
+        styleClass="h-[40px] w-[151px] web:h-[50px] web:w-[215px]"
+      />
+    </nav>
+  );
+};
+
+export default DetailBottomButton;

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMoreButton.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMoreButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Button from "@/app/_component/common/atom/Button";
+
+interface Props {
+  setViewMore: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const DetailMoreButton = ({ setViewMore }: Props) => {
+  return (
+    <div>
+      <Button
+        text="더보기"
+        onClickFn={() => {
+          setViewMore(true);
+        }}
+      />
+    </div>
+  );
+};
+
+export default DetailMoreButton;

--- a/src/app/(non-navbar)/items/[id]/_component/DetailSwiper.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailSwiper.tsx
@@ -12,26 +12,12 @@ import "swiper/css/pagination";
 
 SwiperCore.use([Navigation, Scrollbar, Autoplay]);
 
-const DetailSwiper = () => {
+interface Props {
+  imgUrls: string[];
+}
+
+const DetailSwiper = ({ imgUrls }: Props) => {
   const [slideIndex, setSlideIndex] = useState(0);
-  const slideData = [
-    {
-      id: 1,
-      img: "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
-    },
-    {
-      id: 2,
-      img: "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_2_953.jpg",
-    },
-    {
-      id: 3,
-      img: "https://tourimage.interpark.com/Spot/137/12348/201605/6359918902617540740.jpg",
-    },
-    {
-      id: 4,
-      img: "https://tourimage.interpark.com/Spot/137/12348/201605/6359918902617540741.jpg",
-    },
-  ];
 
   const handleSlideChange = (swiper: { realIndex: SetStateAction<number> }) => {
     setSlideIndex(swiper.realIndex);
@@ -46,11 +32,11 @@ const DetailSwiper = () => {
         }}
         onSlideChange={handleSlideChange}
       >
-        {slideData.map((slide) => (
-          <SwiperSlide key={slide.id}>
+        {imgUrls.map((img) => (
+          <SwiperSlide key={img}>
             <div className="w-full h-[320px]">
               <img
-                src={slide.img}
+                src={img}
                 alt="패키지 상세 이미지"
                 className="w-full h-full object-cover"
               />

--- a/src/app/(non-navbar)/items/[id]/_component/DetailSwiper.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailSwiper.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { SetStateAction, useState } from "react";
+import SwiperCore from "swiper";
+import { Autoplay, Navigation, Scrollbar } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
+import SwiperBadge from "./SwiperBadge";
+
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+
+SwiperCore.use([Navigation, Scrollbar, Autoplay]);
+
+const DetailSwiper = () => {
+  const [slideIndex, setSlideIndex] = useState(0);
+  const slideData = [
+    {
+      id: 1,
+      img: "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+    },
+    {
+      id: 2,
+      img: "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_2_953.jpg",
+    },
+    {
+      id: 3,
+      img: "https://tourimage.interpark.com/Spot/137/12348/201605/6359918902617540740.jpg",
+    },
+    {
+      id: 4,
+      img: "https://tourimage.interpark.com/Spot/137/12348/201605/6359918902617540741.jpg",
+    },
+  ];
+
+  const handleSlideChange = (swiper: { realIndex: SetStateAction<number> }) => {
+    setSlideIndex(swiper.realIndex);
+  };
+
+  return (
+    <div className="relative swiper-container">
+      <Swiper
+        autoplay={{
+          delay: 2500,
+          disableOnInteraction: false,
+        }}
+        onSlideChange={handleSlideChange}
+      >
+        {slideData.map((slide) => (
+          <SwiperSlide key={slide.id}>
+            <div className="w-full h-[320px]">
+              <img
+                src={slide.img}
+                alt="패키지 상세 이미지"
+                className="w-full h-full object-cover"
+              />
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      <SwiperBadge slideIndex={slideIndex} slideLength={4} />
+    </div>
+  );
+};
+
+export default DetailSwiper;

--- a/src/app/(non-navbar)/items/[id]/_component/DettailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DettailMain.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import usePackageDetailQuery from "@/hooks/query/usePackageDetailQuery";
+import { useParams } from "next/navigation";
+import DetailSwiper from "./DetailSwiper";
+import ItemDetailBottom from "./ItemDetailBottom";
+
+const DettailMain = () => {
+  const params = useParams();
+
+  const { data: packageDetail } = usePackageDetailQuery(params.id);
+
+  return (
+    <>
+      <DetailSwiper imgUrls={packageDetail.data.imageUrls} />
+      <ItemDetailBottom />
+    </>
+  );
+};
+
+export default DettailMain;

--- a/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+import DetailBottomButton from "./DetailBottomButton";
+import DetailMoreButton from "./DetailMoreButton";
+
+const ItemDetailBottom = () => {
+  const [viewMore, setViewMore] = useState(false);
+
+  const getNavStyle = () => {
+    if (viewMore) return "";
+    else return "fixed bottom-0 web:w-[500px]";
+  };
+
+  return (
+    <div className={`${getNavStyle()} w-full`}>
+      {viewMore || <DetailMoreButton setViewMore={setViewMore} />}
+      <DetailBottomButton />
+    </div>
+  );
+};
+
+export default ItemDetailBottom;

--- a/src/app/(non-navbar)/items/[id]/_component/SwiperBadge.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/SwiperBadge.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  slideIndex: number;
+  slideLength: number;
+}
+
+const SwiperBadge = ({ slideIndex, slideLength }: Props) => {
+  return (
+    <div className="absolute flex items-center justify-center right-6 bottom-4 px-2 z-10 bg-grey-e rounded-lg web:px-3">
+      <span className="text-[10px] text-black-6 font-light web:text-sm">
+        {slideIndex + 1} / {slideLength}
+      </span>
+    </div>
+  );
+};
+
+export default SwiperBadge;

--- a/src/app/(non-navbar)/items/[id]/page.tsx
+++ b/src/app/(non-navbar)/items/[id]/page.tsx
@@ -1,13 +1,28 @@
+import getPackageDetail from "@/api/items/getPackageDetail";
 import DefaultHeader from "@/app/_component/common/layout/DefaultHeader";
-import DetailSwiper from "./_component/DetailSwiper";
-import ItemDetailBottom from "./_component/ItemDetailBottom";
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from "@tanstack/react-query";
+import DettailMain from "./_component/DettailMain";
 
-const ItemsPage = () => {
+const ItemsPage = async ({ params }: { params: { id: string } }) => {
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["package-detail", params.id],
+    queryFn: async () => {
+      return getPackageDetail(Number(params.id));
+    },
+  });
+  const dehydrateState = dehydrate(queryClient);
+
   return (
     <div className="w-full">
       <DefaultHeader theme="main" />
-      <DetailSwiper />
-      <ItemDetailBottom />
+      <HydrationBoundary state={dehydrateState}>
+        <DettailMain />
+      </HydrationBoundary>
     </div>
   );
 };

--- a/src/app/(non-navbar)/items/[id]/page.tsx
+++ b/src/app/(non-navbar)/items/[id]/page.tsx
@@ -1,0 +1,15 @@
+import DefaultHeader from "@/app/_component/common/layout/DefaultHeader";
+import DetailSwiper from "./_component/DetailSwiper";
+import ItemDetailBottom from "./_component/ItemDetailBottom";
+
+const ItemsPage = () => {
+  return (
+    <div className="w-full">
+      <DefaultHeader theme="main" />
+      <DetailSwiper />
+      <ItemDetailBottom />
+    </div>
+  );
+};
+
+export default ItemsPage;

--- a/src/hooks/query/usePackageDetailQuery.ts
+++ b/src/hooks/query/usePackageDetailQuery.ts
@@ -1,7 +1,7 @@
 import getPackageDetail from "@/api/items/getPackageDetail";
 import { useQuery } from "@tanstack/react-query";
 
-const usePackageDetailQuery = (id: string | string[], date: string | null) => {
+const usePackageDetailQuery = (id: string | string[], date?: string | null) => {
   return useQuery({
     queryKey: ["package-detail", id],
     queryFn: async () => {

--- a/src/mocks/data/packageScheduleData.ts
+++ b/src/mocks/data/packageScheduleData.ts
@@ -146,6 +146,9 @@ export const details = [
     },
     imageUrls: [
       "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_1_880.jpg",
+      "https://tourimage.interpark.com/product/tour/00161/A50/1000/A5019085_2_953.jpg",
+      "https://tourimage.interpark.com/Spot/137/12348/201605/6359918902617540740.jpg",
+      "https://tourimage.interpark.com/Spot/137/12348/201605/6359918902617540741.jpg",
     ],
     nationName: "나라 이름",
     continentName: "대륙 이름",


### PR DESCRIPTION
## 구현 내용
- 상세 페이지에 이미지 캐러셀을 추가 하였습니다.
(마우스 or 2.5초 후 다음 이미지, 이미지 순서 숫자 표시)
- 데이터를 MSW와 연결하였습니다.
웹
![스크린샷 2024-01-15 233426](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/4d4a5c9d-f2b3-4831-87fe-ad95ac06d243)
모바일
![스크린샷 2024-01-15 233419](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/9a91b88f-cddf-4bae-affe-34040b2d3387)

## 기타
- 스타일은 지속적으로 바뀔 수 있어서 스타일을 제외한 기능을 바탕으로 리뷰 해주시면 감사드리겠습니다.

## 이슈번호
X
