### PR TITLE
Feat: 패키지 상세 페이지 하단 바 기능 추가

### DIFF
--- a/src/app/(non-navbar)/items/[id]/_component/DetailBottomButton.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailBottomButton.tsx
@@ -1,20 +1,32 @@
-import Button from "@/app/_component/common/atom/Button";
+"use client";
 
-const DetailBottomButton = () => {
+interface Props {
+  viewMore: boolean;
+}
+
+const DetailBottomButton = ({ viewMore }: Props) => {
+  const getBorderStyle = () => {
+    if (!viewMore) return "";
+
+    return "border-t-[0.6px] border-solid border-grey-d";
+  };
+
   return (
     <nav
-      className={`flex justify-between items-center w-full h-20 px-6 py-5 web:h-24 bg-white`}
+      className={`flex justify-between items-center p-6 h-20 bg-white ${getBorderStyle()} web:p-4 web:w-[500px]`}
     >
-      <Button
-        text="1:1 비교하기"
-        theme="wide"
-        styleClass="h-[40px] w-[151px] web:h-[50px] web:w-[215px]"
-      />
-      <Button
-        text="예약하기"
-        theme="wide"
-        styleClass="h-[40px] w-[151px] web:h-[50px] web:w-[215px]"
-      />
+      <button
+        type="button"
+        className="w-[151px] h-[40px] bg-pink rounded-lg text-white text-lg font-bold web:w-[210px]"
+      >
+        1:1 비교하기
+      </button>
+      <button
+        type="button"
+        className="w-[151px] h-[40px] bg-pink rounded-lg text-white text-lg font-bold web:w-[210px]"
+      >
+        예약하기
+      </button>
     </nav>
   );
 };

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -3,19 +3,25 @@
 import CenterContainer from "@/app/_component/common/atom/CenterContainer";
 import usePackageDetailQuery from "@/hooks/query/usePackageDetailQuery";
 import { useParams } from "next/navigation";
+import { useState } from "react";
 import BadgeList from "./BadgeList";
 import DetailSwiper from "./DetailSwiper";
 import DetailTypography from "./DetailTypography";
+import ItemDetailBottom from "./ItemDetailBottom";
 import PackageInfo from "./PackageInfo";
 import PackageTagBadge from "./PackageTagBadge";
-// import ItemDetailBottom from "./ItemDetailBottom";
 
 const DettailMain = () => {
   const params = useParams();
   const { data: packageDetail } = usePackageDetailQuery(params.id);
+  const [viewMore, setViewMore] = useState(false);
 
   return (
-    <div className="overflow-hidden">
+    <div
+      className={`overflow-hidden ${
+        viewMore ? "pb-[30px]" : "h-[700px] web:h-[630px]"
+      }`}
+    >
       <DetailSwiper imgUrls={packageDetail.data.imageUrls} />
       <div className="px-6 web:px-4">
         <BadgeList>
@@ -50,7 +56,7 @@ const DettailMain = () => {
         </div>
         <PackageInfo infoData={packageDetail.data.info} />
       </div>
-      {/* <ItemDetailBottom /> */}
+      <ItemDetailBottom viewMore={viewMore} setViewMore={setViewMore} />
     </div>
   );
 };

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMoreButton.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMoreButton.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Button from "@/app/_component/common/atom/Button";
 
 interface Props {
@@ -8,12 +6,13 @@ interface Props {
 
 const DetailMoreButton = ({ setViewMore }: Props) => {
   return (
-    <div>
+    <div className="flex items-center justify-center h-36 bg-gradient-white web:h-20">
       <Button
         text="더보기"
         onClickFn={() => {
           setViewMore(true);
         }}
+        styleClass="border-[0.6px] border-solid border-grey-a rounded-[52px] py-1 px-2 text-black-6 bg-white"
       />
     </div>
   );

--- a/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
@@ -1,21 +1,28 @@
 "use client";
 
-import { useState } from "react";
+import useScrollUp from "@/hooks/useScrollUp";
 import DetailBottomButton from "./DetailBottomButton";
 import DetailMoreButton from "./DetailMoreButton";
 
-const ItemDetailBottom = () => {
-  const [viewMore, setViewMore] = useState(false);
+interface Props {
+  viewMore: boolean;
+  setViewMore: React.Dispatch<React.SetStateAction<boolean>>;
+}
 
-  const getNavStyle = () => {
-    if (viewMore) return "";
-    else return "fixed bottom-0 web:w-[500px]";
+const ItemDetailBottom = ({ viewMore, setViewMore }: Props) => {
+  const isScrollUp = useScrollUp();
+
+  const getAnimation = () => {
+    if (!viewMore) return "";
+
+    if (isScrollUp) return "animate-positionTopAnimation";
+    else return "animate-positionTopAnimationReverse";
   };
 
   return (
-    <div className={`${getNavStyle()} w-full`}>
+    <div className={`fixed bottom-0 ${getAnimation()} w-full web:w-[500px]`}>
       {viewMore || <DetailMoreButton setViewMore={setViewMore} />}
-      <DetailBottomButton />
+      <DetailBottomButton viewMore={viewMore} />
     </div>
   );
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,6 +67,10 @@ const config: Config = {
       boxShadow: {
         dark: "rgba(0, 0, 0, 0.16) 0px 3px 6px, rgba(0, 0, 0, 0.23) 0px 3px 6px",
       },
+      backgroundImage: {
+        "gradient-white":
+          "linear-gradient(0deg, rgba(255,255,255,1) 5%, rgba(255,255,255,0) 100%)",
+      },
       keyframes: {
         // 약관 동의 애니메이션
         transparencyAnimation: {


### PR DESCRIPTION
## 구현 내용
- 상세 페이지의 하단 바를 추가하였습니다. 기존 하단 내비게이션과 기능적으로 많이 다르기 때문에  non-navbar에 새로운 컴포넌트로 제작하였습니다.

![스크린샷 2024-01-16 162728](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/cadb3314-5ee1-4969-af54-df4fb0a686c8)

![스크린샷 2024-01-16 163422](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/cc4953fa-c598-4675-b3a5-1862f3cdce95)

## 기타
X

## 이슈번호
X