### PR TITLE
Feat: 상세 페이지 타이포그래피 컴포넌트 글자 웹 크기 추가, 레이아웃 추가

### DIFF
--- a/src/app/(non-navbar)/items/[id]/_component/ChangeDateButton.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ChangeDateButton.tsx
@@ -1,0 +1,37 @@
+import CenterContainer from "@/app/_component/common/atom/CenterContainer";
+import { Reservation } from "@/app/types";
+import DetailTypography from "./DetailTypography";
+
+interface Props {
+  reservation: Reservation;
+}
+
+const ChangeDateButton = ({ reservation }: Props) => {
+  return (
+    <div className="mt-4">
+      <button
+        type="button"
+        className="w-full py-3 mb-2 rounded-[58px] border-[0.6px] border-solid border-pink"
+      >
+        <DetailTypography color="pink" size={14} bold={500} align="center">
+          출발일 변경
+        </DetailTypography>
+      </button>
+      <CenterContainer>
+        <DetailTypography color={4} size={13} bold={500}>
+          예약
+        </DetailTypography>
+        &nbsp;
+        <DetailTypography color="pink" size={13} bold={600}>
+          {reservation.current}명
+        </DetailTypography>
+        &nbsp;
+        <DetailTypography color={8} bold={500}>
+          / 잔여석 {reservation.remain}명, 최소 출발 {reservation.min}명
+        </DetailTypography>
+      </CenterContainer>
+    </div>
+  );
+};
+
+export default ChangeDateButton;

--- a/src/app/(non-navbar)/items/[id]/_component/DetailBottomButton.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailBottomButton.tsx
@@ -1,20 +1,32 @@
-import Button from "@/app/_component/common/atom/Button";
+"use client";
 
-const DetailBottomButton = () => {
+interface Props {
+  viewMore: boolean;
+}
+
+const DetailBottomButton = ({ viewMore }: Props) => {
+  const getBorderStyle = () => {
+    if (!viewMore) return "";
+
+    return "border-t-[0.6px] border-solid border-grey-d";
+  };
+
   return (
     <nav
-      className={`flex justify-between items-center w-full h-20 px-6 py-5 web:h-24 bg-white`}
+      className={`flex justify-between items-center p-6 h-20 bg-white ${getBorderStyle()} web:p-4 web:w-[500px]`}
     >
-      <Button
-        text="1:1 비교하기"
-        theme="wide"
-        styleClass="h-[40px] w-[151px] web:h-[50px] web:w-[215px]"
-      />
-      <Button
-        text="예약하기"
-        theme="wide"
-        styleClass="h-[40px] w-[151px] web:h-[50px] web:w-[215px]"
-      />
+      <button
+        type="button"
+        className="w-[151px] h-[40px] bg-pink rounded-lg text-white text-lg font-bold web:w-[210px]"
+      >
+        1:1 비교하기
+      </button>
+      <button
+        type="button"
+        className="w-[151px] h-[40px] bg-pink rounded-lg text-white text-lg font-bold web:w-[210px]"
+      >
+        예약하기
+      </button>
     </nav>
   );
 };

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -3,19 +3,25 @@
 import CenterContainer from "@/app/_component/common/atom/CenterContainer";
 import usePackageDetailQuery from "@/hooks/query/usePackageDetailQuery";
 import { useParams } from "next/navigation";
+import { useState } from "react";
 import BadgeList from "./BadgeList";
 import DetailSwiper from "./DetailSwiper";
 import DetailTypography from "./DetailTypography";
+import ItemDetailBottom from "./ItemDetailBottom";
 import PackageInfo from "./PackageInfo";
 import PackageTagBadge from "./PackageTagBadge";
-// import ItemDetailBottom from "./ItemDetailBottom";
 
 const DettailMain = () => {
   const params = useParams();
   const { data: packageDetail } = usePackageDetailQuery(params.id);
+  const [viewMore, setViewMore] = useState(false);
 
   return (
-    <div className="overflow-hidden">
+    <div
+      className={`overflow-hidden ${
+        viewMore ? "pb-[30px]" : "h-[700px] web:h-[630px]"
+      }`}
+    >
       <DetailSwiper imgUrls={packageDetail.data.imageUrls} />
       <div className="px-6 web:px-4">
         <BadgeList>
@@ -50,7 +56,7 @@ const DettailMain = () => {
         </div>
         <PackageInfo infoData={packageDetail.data.info} />
       </div>
-      {/* <ItemDetailBottom /> */}
+      <ItemDetailBottom viewMore={viewMore} setViewMore={setViewMore} />
     </div>
   );
 };

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -14,7 +14,7 @@ import PackageTagBadge from "./PackageTagBadge";
 import TravelDate from "./TravelDate";
 import ChangeDateButton from "./ChangeDateButton";
 
-const DettailMain = () => {
+const DetailMain = () => {
   const params = useParams();
   const { data: packageDetail } = usePackageDetailQuery(params.id);
   const [viewMore, setViewMore] = useState(false);
@@ -74,4 +74,4 @@ const DettailMain = () => {
   );
 };
 
-export default DettailMain;
+export default DetailMain;

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import CenterContainer from "@/app/_component/common/atom/CenterContainer";
-import { DateTime } from "@/app/types";
+import { DateTime, Reservation } from "@/app/types";
 import usePackageDetailQuery from "@/hooks/query/usePackageDetailQuery";
 import { useParams } from "next/navigation";
 import { useState } from "react";
@@ -12,13 +12,14 @@ import ItemDetailBottom from "./ItemDetailBottom";
 import PackageInfo from "./PackageInfo";
 import PackageTagBadge from "./PackageTagBadge";
 import TravelDate from "./TravelDate";
+import ChangeDateButton from "./ChangeDateButton";
 
 const DettailMain = () => {
   const params = useParams();
   const { data: packageDetail } = usePackageDetailQuery(params.id);
   const [viewMore, setViewMore] = useState(false);
 
-  // console.log(packageDetail);
+  // console.log(packageDetail.data.reservation);
 
   return (
     <div
@@ -63,6 +64,9 @@ const DettailMain = () => {
           departureDatetime={packageDetail.data.departureDatetime as DateTime}
           endDatetime={packageDetail.data.endDatetime as DateTime}
           transporation={packageDetail.data.transporation as string}
+        />
+        <ChangeDateButton
+          reservation={packageDetail.data.reservation as Reservation}
         />
       </div>
       <ItemDetailBottom viewMore={viewMore} setViewMore={setViewMore} />

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import CenterContainer from "@/app/_component/common/atom/CenterContainer";
+import { DateTime } from "@/app/types";
 import usePackageDetailQuery from "@/hooks/query/usePackageDetailQuery";
 import { useParams } from "next/navigation";
 import { useState } from "react";
@@ -10,11 +11,14 @@ import DetailTypography from "./DetailTypography";
 import ItemDetailBottom from "./ItemDetailBottom";
 import PackageInfo from "./PackageInfo";
 import PackageTagBadge from "./PackageTagBadge";
+import TravelDate from "./TravelDate";
 
 const DettailMain = () => {
   const params = useParams();
   const { data: packageDetail } = usePackageDetailQuery(params.id);
   const [viewMore, setViewMore] = useState(false);
+
+  // console.log(packageDetail);
 
   return (
     <div
@@ -55,6 +59,11 @@ const DettailMain = () => {
           </CenterContainer>
         </div>
         <PackageInfo infoData={packageDetail.data.info} />
+        <TravelDate
+          departureDatetime={packageDetail.data.departureDatetime as DateTime}
+          endDatetime={packageDetail.data.endDatetime as DateTime}
+          transporation={packageDetail.data.transporation as string}
+        />
       </div>
       <ItemDetailBottom viewMore={viewMore} setViewMore={setViewMore} />
     </div>

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMoreButton.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMoreButton.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Button from "@/app/_component/common/atom/Button";
 
 interface Props {
@@ -8,12 +6,13 @@ interface Props {
 
 const DetailMoreButton = ({ setViewMore }: Props) => {
   return (
-    <div>
+    <div className="flex items-center justify-center h-36 bg-gradient-white web:h-20">
       <Button
         text="더보기"
         onClickFn={() => {
           setViewMore(true);
         }}
+        styleClass="border-[0.6px] border-solid border-grey-a rounded-[52px] py-1 px-2 text-black-6 bg-white"
       />
     </div>
   );

--- a/src/app/(non-navbar)/items/[id]/_component/DetailTypography.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailTypography.tsx
@@ -42,13 +42,13 @@ const DetailTypography = ({
   };
 
   const generateSizeStyle = () => {
-    if (size === 10) return "text-[10px]";
-    if (size === 12) return "text-xs";
-    if (size === 13) return "text-[13px]";
-    if (size === 14) return "text-sm";
-    if (size === 16) return "";
-    if (size === 18) return "text-lg";
-    if (size === 20) return "text-xl";
+    if (size === 10) return "text-[10px] web:text-xs";
+    if (size === 12) return "text-xs web:text-sm";
+    if (size === 13) return "text-[13px] web:text-[15px]";
+    if (size === 14) return "text-sm web:text-base";
+    if (size === 16) return "web:text-lg";
+    if (size === 18) return "text-lg web:text-xl";
+    if (size === 20) return "text-xl web:text-2xl";
     return "text-xs";
   };
 

--- a/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
@@ -1,21 +1,28 @@
 "use client";
 
-import { useState } from "react";
+import useScrollUp from "@/hooks/useScrollUp";
 import DetailBottomButton from "./DetailBottomButton";
 import DetailMoreButton from "./DetailMoreButton";
 
-const ItemDetailBottom = () => {
-  const [viewMore, setViewMore] = useState(false);
+interface Props {
+  viewMore: boolean;
+  setViewMore: React.Dispatch<React.SetStateAction<boolean>>;
+}
 
-  const getNavStyle = () => {
-    if (viewMore) return "";
-    else return "fixed bottom-0 web:w-[500px]";
+const ItemDetailBottom = ({ viewMore, setViewMore }: Props) => {
+  const isScrollUp = useScrollUp();
+
+  const getAnimation = () => {
+    if (!viewMore) return "";
+
+    if (isScrollUp) return "animate-positionTopAnimation";
+    else return "animate-positionTopAnimationReverse";
   };
 
   return (
-    <div className={`${getNavStyle()} w-full`}>
+    <div className={`fixed bottom-0 ${getAnimation()} w-full web:w-[500px]`}>
       {viewMore || <DetailMoreButton setViewMore={setViewMore} />}
-      <DetailBottomButton />
+      <DetailBottomButton viewMore={viewMore} />
     </div>
   );
 };

--- a/src/app/(non-navbar)/items/[id]/_component/TravelDate.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/TravelDate.tsx
@@ -14,26 +14,38 @@ const TravelDate = ({
   transporation,
 }: Props) => {
   return (
-    <div className="border-2 border-solid border-red py-6 px-8">
-      <div className="flex items-center">
-        <DetailTypography color={4}>교통편</DetailTypography>
-        <DetailTypography size={14} bold={600}>
-          {transporation}
-        </DetailTypography>
+    <div className="rounded-lg bg-[#FAFAFA] py-6 px-8 mt-[29px]">
+      <div className="flex items-center mb-[11px]">
+        <div className="w-20">
+          <DetailTypography color={4}>교통편</DetailTypography>
+        </div>
+        <div>
+          <DetailTypography size={14} bold={600}>
+            {transporation}
+          </DetailTypography>
+        </div>
+      </div>
+      <div className="flex items-center mb-[11px]">
+        <div className="w-20">
+          <DetailTypography color={4}>출발일시</DetailTypography>
+        </div>
+        <div>
+          <DetailTypography size={14} bold={600}>
+            {ReplaceHyphenWithDot(departureDatetime.date)}{" "}
+            {departureDatetime.dayOfWeek} {departureDatetime.time}
+          </DetailTypography>
+        </div>
       </div>
       <div className="flex items-center">
-        <DetailTypography color={4}>출발일시</DetailTypography>
-        <DetailTypography size={14} bold={600}>
-          {ReplaceHyphenWithDot(departureDatetime.date)}{" "}
-          {departureDatetime.dayOfWeek} {departureDatetime.time}
-        </DetailTypography>
-      </div>
-      <div className="flex items-center">
-        <DetailTypography color={4}>도착일시</DetailTypography>
-        <DetailTypography size={14} bold={600}>
-          {ReplaceHyphenWithDot(endDatetime.date)} {endDatetime.dayOfWeek}{" "}
-          {endDatetime.time}
-        </DetailTypography>
+        <div className="w-20">
+          <DetailTypography color={4}>도착일시</DetailTypography>
+        </div>
+        <div>
+          <DetailTypography size={14} bold={600}>
+            {ReplaceHyphenWithDot(endDatetime.date)} {endDatetime.dayOfWeek}{" "}
+            {endDatetime.time}
+          </DetailTypography>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(non-navbar)/items/[id]/_component/TravelDate.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/TravelDate.tsx
@@ -1,0 +1,42 @@
+import { DateTime } from "@/app/types";
+import ReplaceHyphenWithDot from "@/utils/ReplaceHyphenWithDot";
+import DetailTypography from "./DetailTypography";
+
+interface Props {
+  departureDatetime: DateTime;
+  endDatetime: DateTime;
+  transporation: string;
+}
+
+const TravelDate = ({
+  departureDatetime,
+  endDatetime,
+  transporation,
+}: Props) => {
+  return (
+    <div className="border-2 border-solid border-red py-6 px-8">
+      <div className="flex items-center">
+        <DetailTypography color={4}>교통편</DetailTypography>
+        <DetailTypography size={14} bold={600}>
+          {transporation}
+        </DetailTypography>
+      </div>
+      <div className="flex items-center">
+        <DetailTypography color={4}>출발일시</DetailTypography>
+        <DetailTypography size={14} bold={600}>
+          {ReplaceHyphenWithDot(departureDatetime.date)}{" "}
+          {departureDatetime.dayOfWeek} {departureDatetime.time}
+        </DetailTypography>
+      </div>
+      <div className="flex items-center">
+        <DetailTypography color={4}>도착일시</DetailTypography>
+        <DetailTypography size={14} bold={600}>
+          {ReplaceHyphenWithDot(endDatetime.date)} {endDatetime.dayOfWeek}{" "}
+          {endDatetime.time}
+        </DetailTypography>
+      </div>
+    </div>
+  );
+};
+
+export default TravelDate;

--- a/src/app/(non-navbar)/items/[id]/page.tsx
+++ b/src/app/(non-navbar)/items/[id]/page.tsx
@@ -7,6 +7,14 @@ import {
 } from "@tanstack/react-query";
 import DetailMain from "./_component/DetailMain";
 
+export const generateStaticParams = () => {
+  const ids = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+  return ids.map((id) => ({
+    slug: id,
+  }));
+};
+
 const ItemsPage = async ({ params }: { params: { id: string } }) => {
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({

--- a/src/app/(non-navbar)/items/page.tsx
+++ b/src/app/(non-navbar)/items/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+const ItemsPage = () => {
+  const router = useRouter();
+  return (
+    <div>
+      <h1>요청하신 페이지가 존재하지 않습니다</h1>
+      <p>다른 상품을 찾아보세요</p>
+      <button
+        type="button"
+        onClick={() => {
+          router.push("/");
+        }}
+      >
+        홈으로 바로가기
+      </button>
+    </div>
+  );
+};
+
+export default ItemsPage;

--- a/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
+++ b/src/app/(non-navbar)/schedule/[id]/_component/SelectedProduct.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import useScheduleDateStore from "@/store/useScheduleDateStore";
+import ReplaceHyphenWithDot from "@/utils/ReplaceHyphenWithDot";
 
 const SelectedProduct = () => {
   const scheduleDate = useScheduleDateStore();
-
-  const formatSelectedItemDate = (date: string) => {
-    return date.replace(/-/g, ".");
-  };
 
   if (scheduleDate.data === null) {
     return (
@@ -42,7 +39,7 @@ const SelectedProduct = () => {
         <div className="flex flex-col justify-center">
           <div>
             <span className="text-black-2 font-medium mr-3 web:text-lg">
-              {formatSelectedItemDate(scheduleDate.data.departureDatetime.date)}
+              {ReplaceHyphenWithDot(scheduleDate.data.departureDatetime.date)}
             </span>
             <span className="text-black-4 text-xs web:text-sm">
               {scheduleDate.data.departureDatetime.time} 출발

--- a/src/utils/ReplaceHyphenWithDot.ts
+++ b/src/utils/ReplaceHyphenWithDot.ts
@@ -1,0 +1,5 @@
+const ReplaceHyphenWithDot = (date: string) => {
+  return date.replace(/-/g, ".");
+};
+
+export default ReplaceHyphenWithDot;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,6 +67,10 @@ const config: Config = {
       boxShadow: {
         dark: "rgba(0, 0, 0, 0.16) 0px 3px 6px, rgba(0, 0, 0, 0.23) 0px 3px 6px",
       },
+      backgroundImage: {
+        "gradient-white":
+          "linear-gradient(0deg, rgba(255,255,255,1) 5%, rgba(255,255,255,0) 100%)",
+      },
       keyframes: {
         // 약관 동의 애니메이션
         transparencyAnimation: {


### PR DESCRIPTION
## 구현 내용
- 웹에서 글자가 좀 더 크게 보이도록 컴포넌트를 수정하였습니다.
- 날자 데이터 문자 변경 함수를 유틸 함수로 분리하였습니다.  ex) "2024-03-02" -> "2024.03.02" 
- 상세 페이지 레이아웃을 추가 하였습니다.
- 상세 페이지 items -> page.tsx는 배포 확인 용 임시 코드입니다.

## 기타
X

## 이슈번호
X
