### PR TITLE
Feat: 결제페이지 프론트기능구현끝

### DIFF
--- a/src/app/(navbar)/payment/_component/ReservationDone.tsx
+++ b/src/app/(navbar)/payment/_component/ReservationDone.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import Image from "next/image";
 import Step from "./Step";
+import ProgressBar from "./ProgressBar";
 
 const ReservationDone = () => {
   return (
     <div className="mx-4">
+      <div className="sticky top-0">
+        <ProgressBar progress={100} />
+      </div>
       <div className="mt-10 mb-5">
         <h3 className="flex">
           <Image

--- a/src/app/(navbar)/payment/_component/ReservationDone.tsx
+++ b/src/app/(navbar)/payment/_component/ReservationDone.tsx
@@ -6,7 +6,7 @@ import ProgressBar from "./ProgressBar";
 const ReservationDone = () => {
   return (
     <div className="mx-4">
-      <div className="sticky top-0">
+      <div className="sticky top-0 pb-2 bg-white">
         <ProgressBar progress={100} />
       </div>
       <div className="mt-10 mb-5">

--- a/src/app/(navbar)/payment/_component/ReservationInfo.tsx
+++ b/src/app/(navbar)/payment/_component/ReservationInfo.tsx
@@ -116,7 +116,7 @@ const ReservationInfo = ({ onComplete }: Props) => {
 
   return (
     <div>
-      <div className="sticky top-0">
+      <div className="sticky top-0 pb-2 bg-white z-10">
         <ProgressBar progress={progress} />
       </div>
       <div className="p-4">

--- a/src/app/(navbar)/payment/_component/ReservationInfo.tsx
+++ b/src/app/(navbar)/payment/_component/ReservationInfo.tsx
@@ -13,6 +13,11 @@ const ReservationInfo = ({ onComplete }: Props) => {
   const [adultClass, setAdultClass] = useState("text-grey-c");
   const [childClass, setChildClass] = useState("text-grey-c");
   const [infantClass, setInfantClass] = useState("text-grey-c");
+  const [adultSelected, setAdultSelected] = useState(false);
+  const [childSelected, setChildSelected] = useState(false);
+  const [infantSelected, setInfantSelected] = useState(false);
+  const [isReservationButtonActive, setIsReservationButtonActive] =
+    useState(false);
   const [progress, setProgress] = useState(0);
   const [sectionStatus, setSectionStatus] = useState({
     section1: false,
@@ -23,9 +28,9 @@ const ReservationInfo = ({ onComplete }: Props) => {
 
   const updateProgress = useCallback(() => {
     const sectionsCompleted = [
-      adultClass !== "text-grey-c",
-      childClass !== "text-grey-c",
-      infantClass !== "text-grey-c",
+      adultSelected,
+      childSelected,
+      infantSelected,
       sectionStatus.section1,
       sectionStatus.section2,
       sectionStatus.section3,
@@ -34,7 +39,16 @@ const ReservationInfo = ({ onComplete }: Props) => {
 
     const newProgress = (sectionsCompleted / 7) * 100;
     setProgress(newProgress);
-  }, [adultClass, childClass, infantClass, sectionStatus]);
+    setIsReservationButtonActive(newProgress === 100);
+  }, [
+    adultSelected,
+    childSelected,
+    infantSelected,
+    sectionStatus.section1,
+    sectionStatus.section2,
+    sectionStatus.section3,
+    sectionStatus.section4,
+  ]);
 
   const [allAgreedImageSrc, setAllAgreedImageSrc] = useState(
     "/icons/checkIcon2.svg",
@@ -42,10 +56,9 @@ const ReservationInfo = ({ onComplete }: Props) => {
 
   const handleSectionChange = (section: string, isActive: boolean) => {
     setSectionStatus((prev) => {
-      if (section in prev) {
-        return { ...prev, [section]: isActive };
-      }
-      return prev;
+      const newStatus = { ...prev, [section]: isActive };
+      updateProgress();
+      return newStatus;
     });
   };
 
@@ -72,22 +85,31 @@ const ReservationInfo = ({ onComplete }: Props) => {
   ]);
 
   const handleAdultChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setAdultSelected(true);
     setAdultClass(
-      event.target.value === "0" ? "text-grey-c" : "text-pink-main",
+      event.target.value === "-" || event.target.value === "0"
+        ? "text-grey-c"
+        : "text-pink-main",
     );
     updateProgress();
   };
 
   const handleChildChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setChildSelected(true);
     setChildClass(
-      event.target.value === "0" ? "text-grey-c" : "text-pink-main",
+      event.target.value === "-" || event.target.value === "0"
+        ? "text-grey-c"
+        : "text-pink-main",
     );
     updateProgress();
   };
 
   const handleInfantChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setInfantSelected(true);
     setInfantClass(
-      event.target.value === "0" ? "text-grey-c" : "text-pink-main",
+      event.target.value === "-" || event.target.value === "0"
+        ? "text-grey-c"
+        : "text-pink-main",
     );
     updateProgress();
   };
@@ -182,6 +204,7 @@ const ReservationInfo = ({ onComplete }: Props) => {
               className={`w-[97px] h-[32px] border border-black-9 rounded-md px-8 appearance-none text-base ${adultClass}`}
               onChange={handleAdultChange}
             >
+              <option value="-">-</option>
               {Array.from({ length: 21 }, (_, i) => (
                 <option key={i} value={i}>
                   {i}
@@ -206,6 +229,7 @@ const ReservationInfo = ({ onComplete }: Props) => {
               className={`w-[97px] h-[32px] border border-black-9 rounded-md px-8 appearance-none text-base ${childClass}`}
               onChange={handleChildChange}
             >
+              <option value="-">-</option>
               {Array.from({ length: 21 }, (_, i) => (
                 <option key={i} value={i}>
                   {i}
@@ -230,6 +254,7 @@ const ReservationInfo = ({ onComplete }: Props) => {
               className={`w-[97px] h-[32px] border border-black-9 rounded-md px-8 appearance-none text-base ${infantClass}`}
               onChange={handleInfantChange}
             >
+              <option value="-">-</option>
               {Array.from({ length: 21 }, (_, i) => (
                 <option key={i} value={i}>
                   {i}
@@ -753,8 +778,10 @@ const ReservationInfo = ({ onComplete }: Props) => {
         <div className="flex justify-center my-6">
           <Button
             text="예약하기"
-            styleClass="rounded-lg bg-pink text-white py-2 px-24 cursor-pointer"
-            onClickFn={onComplete}
+            styleClass={`rounded-lg bg-pink text-white py-2 px-24 cursor-pointer ${
+              !isReservationButtonActive ? "opacity-50 cursor-not-allowed" : ""
+            }`}
+            onClickFn={isReservationButtonActive ? onComplete : undefined}
           />
         </div>
       </div>

--- a/src/app/(navbar)/payment/_component/TopStatus.tsx
+++ b/src/app/(navbar)/payment/_component/TopStatus.tsx
@@ -7,14 +7,20 @@ interface Props {
 const TopStatus = ({ isReservationComplete }: Props) => {
   return (
     <div className="flex justify-between px-4 mt-2 mb-1 font-semibold text-xs">
-      <span className={`text-pink ${isReservationComplete ? "opacity-0" : ""}`}>
-        예약자 정보 입력
-      </span>
-      <span
-        className={`text-pink ${!isReservationComplete ? "opacity-0" : ""}`}
-      >
-        예약완료
-      </span>
+      <div>
+        <span
+          className={`text-pink ${isReservationComplete ? "opacity-0" : ""}`}
+        >
+          예약자 정보 입력
+        </span>
+      </div>
+      <div className="mr-4">
+        <span
+          className={`text-pink ${!isReservationComplete ? "opacity-0" : ""}`}
+        >
+          예약완료
+        </span>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 구현 내용
결제페이지 퍼블리싱과 프론트기능구현 완료하였습니다. API만 연결하면 될것같습니다.
API연결전에 비교페이지 작업먼저 하겠습니다.

프로그레스바가 동적으로 순서에따라 차오릅니다.
약관을 전부읽어야 전부동의가 됩니다.
프로그레스바가 100%일때 예약완료 버튼이 활성화 됩니다.!

## 기타
동영상봐주시면 좋을것 같습니다.!
프로그레스바를 sticky로 위에 붙여 두었는데 어떤가요? 피드백 부탁드립니다
https://github.com/yanolja-finalproject/LETS_FE/assets/59171592/ce35c3fb-409c-4acc-8d4d-b0c70d17b72a

## 이슈번호
❌
