### PR TITLE
Feat: 상세 페이지 리뷰 데이터 연동 및 무한 스크롤 추가

### DIFF
--- a/src/api/items/getPackageReviews.ts
+++ b/src/api/items/getPackageReviews.ts
@@ -1,0 +1,16 @@
+const getPackageReveiws = async (id: number, pageParam: number) => {
+  const result = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/v1/reviews/packages/${id}/list?page=${pageParam}`,
+    {
+      cache: "no-store",
+    },
+  );
+
+  if (!result.ok) {
+    throw new Error("Failed to fetch data");
+  }
+
+  return result.json();
+};
+
+export default getPackageReveiws;

--- a/src/api/items/getPackageScore.ts
+++ b/src/api/items/getPackageScore.ts
@@ -1,0 +1,16 @@
+const getPackageScore = async (id: number) => {
+  const result = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/v1/reviews/packages/${id}/list/summary`,
+    {
+      cache: "no-store",
+    },
+  );
+
+  if (!result.ok) {
+    throw new Error("Failed to fetch data");
+  }
+
+  return result.json();
+};
+
+export default getPackageScore;

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -106,3 +106,5 @@ const DetailMain = () => {
 };
 
 export default DetailMain;
+
+// window.scrollTo({ top: tabY });

--- a/src/app/(non-navbar)/items/[id]/_component/ReviewItem.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ReviewItem.tsx
@@ -1,0 +1,48 @@
+import type { PackageReview } from "@/app/types";
+
+interface Props {
+  review: PackageReview;
+}
+
+const ReviewItem = ({ review }: Props) => {
+  return (
+    <li className="w-full flex flex-col gap-3 mb-[29px]">
+      <h2 className="font-semibold max-w-[93%] truncate web:text-lg">
+        {review.content}
+      </h2>
+      <div className="flex gap-[23px] items-center text-xs web:text-sm">
+        <div className="flex gap-1">
+          <img
+            src="/icons/starIconMini.svg"
+            alt="별 아이콘"
+            className="web:w-4"
+          />
+          <span className="text-black-2">{review.averageStars}</span>
+        </div>
+        <span className="text-black-8"> {review.createdAt}</span>
+      </div>
+      <div className="flex justify-between text-xxs font-medium web:text-sm">
+        <dl className="flex gap-1 p-1 rounded-xl bg-pink-transparent web:px-2">
+          <dt className="text-black-4 ">상품구성</dt>
+          <dd className="text-pink-main"> {review.productScore}</dd>
+        </dl>
+        <dl className="flex gap-1 p-1 rounded-xl bg-pink-transparent web:px-2">
+          <dt className="text-black-6">가이드 친절도</dt>
+          <dd className="text-pink-main"> {review.guideScore}</dd>
+        </dl>
+
+        <div className="flex gap-1 p-1 rounded-xl bg-pink-transparent web:px-2">
+          <span className="text-black-6">일정구성</span>
+          <span className="text-pink-main"> {review.scheduleScore}</span>
+        </div>
+
+        <dl className="flex gap-1 p-1 rounded-xl bg-pink-transparent web:px-2">
+          <dt className="text-black-6">가이드 시간/일정준수</dt>
+          <dd className="text-pink-main"> {review.appointmentScore}</dd>
+        </dl>
+      </div>
+    </li>
+  );
+};
+
+export default ReviewItem;

--- a/src/app/(non-navbar)/items/[id]/_component/ReviewRange.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ReviewRange.tsx
@@ -1,0 +1,39 @@
+interface Props {
+  score: number;
+}
+
+const ReviewRange = ({ score }: Props) => {
+  const getWidth = () => {
+    if (score >= 0.5 && score < 1) {
+      return "before:w-[38px] web:before:w-[54px]";
+    } else if (score >= 1 && score < 1.5) {
+      return "before:w-[57px] web:before:w-[81px]";
+    } else if (score >= 1.5 && score < 2) {
+      return "before:w-[77px] web:before:w-[108px]";
+    } else if (score >= 2 && score < 2.5) {
+      return "before:w-[96px] web:before:w-[135px]";
+    } else if (score >= 2.5 && score < 3) {
+      return "before:w-[115px] web:before:w-[162px]";
+    } else if (score >= 3 && score < 3.5) {
+      return "before:w-[134px] web:before:w-[189px]";
+    } else if (score >= 3.5 && score < 4) {
+      return "before:w-[153px] web:before:w-[261px]";
+    } else if (score >= 4 && score < 4.5) {
+      return "before:w-[173px] web:before:w-[243px]";
+    } else if (score >= 4.5 && score <= 5) {
+      return "before:w-full";
+    } else {
+      return "";
+    }
+  };
+
+  return (
+    <div
+      className={`relative h-3 w-[192px] web:w-[270px] bg-pink-2 rounded-[58px] web:h-4 
+                before:contant-[''] before:h-full before:w-[100px] before:bg-gradient-red before:absolute 
+                before:left-0 before:top-0 before:rounded-[58px] ${getWidth()}`}
+    />
+  );
+};
+
+export default ReviewRange;

--- a/src/app/(non-navbar)/items/[id]/_component/ReviewRangeList.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ReviewRangeList.tsx
@@ -1,0 +1,33 @@
+import DetailTypography from "./DetailTypography";
+import ReviewRange from "./ReviewRange";
+
+interface Props {
+  text: string;
+  score: number;
+}
+
+const ReviewRangeList = ({ text, score }: Props) => {
+  const getSpace = (str: string) => {
+    const newText = str.replace(/\//g, "<br />");
+
+    return newText;
+  };
+
+  return (
+    <div className="flex justify-center items-center mb-3">
+      <div className="w-3/12">
+        <DetailTypography color={6} size={10}>
+          <span dangerouslySetInnerHTML={{ __html: getSpace(text) }} />
+        </DetailTypography>
+      </div>
+      <ReviewRange score={score} />
+      <div className="w-1/12 ml-3">
+        <DetailTypography color={5} size={10}>
+          {score === 5 ? "5.0" : score}
+        </DetailTypography>
+      </div>
+    </div>
+  );
+};
+
+export default ReviewRangeList;

--- a/src/app/(non-navbar)/items/[id]/_component/Reviews.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/Reviews.tsx
@@ -1,7 +1,95 @@
+import type { PackageReview } from "@/app/types";
+import usePackageReveiwQuery from "@/hooks/query/usePackageReveiwQuery";
+import usePackageScoreQuery from "@/hooks/query/usePackageScoreQuery";
+import { useParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+import DetailTypography from "./DetailTypography";
+import ReviewItem from "./ReviewItem";
+import ReviewRangeList from "./ReviewRangeList";
+
 const Reviews = () => {
+  const params = useParams();
+  const {
+    data: reviews,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+  } = usePackageReveiwQuery(params.id as string);
+  const { data: score } = usePackageScoreQuery(params.id as string);
+  console.log(score);
+
+  const boxRef = useRef(null);
+
+  useEffect(() => {
+    const currentRef = boxRef.current;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry.isIntersecting) {
+          if (!isFetching && hasNextPage) {
+            fetchNextPage();
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    if (currentRef) {
+      observer.observe(currentRef);
+    }
+
+    return () => {
+      if (currentRef) {
+        observer.unobserve(currentRef);
+      }
+    };
+  }, [isFetching, hasNextPage, fetchNextPage]);
+
   return (
-    <div>
-      <h1>리뷰</h1>
+    <div className="mt-6">
+      <DetailTypography variant="h1" size={18} bold={600}>
+        리뷰
+      </DetailTypography>
+      <div className="flex mt-8 mb-5">
+        <img
+          src="/icons/starIconMini.svg"
+          alt="별 아이콘"
+          className="mr-2 web:w-4"
+        />
+        <DetailTypography size={18} bold={700}>
+          {score.data.averageStars} 받은 상품이예요
+        </DetailTypography>
+      </div>
+      <div className="mb-8">
+        <ReviewRangeList
+          text="상품구성"
+          score={score.data.averageProductScore}
+        />
+        <ReviewRangeList
+          text="일정구성"
+          score={score.data.averageScheduleScore}
+        />
+        <ReviewRangeList
+          text="가이드 친절도"
+          score={score.data.averageGuideScore}
+        />
+        <ReviewRangeList
+          text="가이드 시간/일정수준"
+          score={score.data.averageAppointmentScore}
+        />
+      </div>
+
+      {reviews?.pages.map((page) => {
+        return (
+          <ul>
+            {page.data.data.map((review: PackageReview) => {
+              return <ReviewItem key={review.reviewId} review={review} />;
+            })}
+          </ul>
+        );
+      })}
+      <div ref={boxRef} className="w-full h-24" />
     </div>
   );
 };

--- a/src/app/(non-navbar)/items/[id]/_component/ScheduleDetail.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ScheduleDetail.tsx
@@ -1,5 +1,5 @@
 import ColorContainer from "@/app/_component/common/atom/ColorContainer";
-import type { DateTime } from "@/app/types";
+import type { DateTime, ScheduleInfo } from "@/app/types";
 import { packageSchedules } from "@/mocks/data/packageScheduleData";
 import ReplaceHyphenWithDot from "@/utils/ReplaceHyphenWithDot";
 import DetailTypography from "./DetailTypography";
@@ -7,14 +7,6 @@ import DetailTypography from "./DetailTypography";
 interface Props {
   departureDatetime: DateTime;
   endDatetime: DateTime;
-}
-
-interface ScheduleInfo {
-  day: number;
-  schedule: string[];
-  breakfast: string;
-  lunch: string;
-  dinner: string;
 }
 
 const ScheduleDetail = ({ departureDatetime, endDatetime }: Props) => {
@@ -90,7 +82,7 @@ const ScheduleDetail = ({ departureDatetime, endDatetime }: Props) => {
 
   return (
     <div className="mt-6">
-      <DetailTypography variant="h1" size={18} bold={600} styleClass="mt-6">
+      <DetailTypography variant="h1" size={18} bold={600}>
         일정표
       </DetailTypography>
       <ColorContainer bg="gray" size="sm">

--- a/src/app/(non-navbar)/items/[id]/page.tsx
+++ b/src/app/(non-navbar)/items/[id]/page.tsx
@@ -1,4 +1,6 @@
 import getPackageDetail from "@/api/items/getPackageDetail";
+import getPackageReveiws from "@/api/items/getPackageReviews";
+import getPackageScore from "@/api/items/getPackageScore";
 import DefaultHeader from "@/app/_component/common/layout/DefaultHeader";
 import type { PackageResponseData } from "@/app/types";
 import {
@@ -28,6 +30,18 @@ const ItemsPage = async ({ params }: { params: { id: string } }) => {
     queryFn: async () => {
       return getPackageDetail(Number(params.id));
     },
+  });
+  await queryClient.prefetchQuery({
+    queryKey: ["package-detail", "score"],
+    queryFn: async () => {
+      return getPackageScore(Number(params.id));
+    },
+  });
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: ["package-detail", "reviews"],
+    queryFn: ({ pageParam = 1 }) =>
+      getPackageReveiws(Number(params.id), pageParam),
+    initialPageParam: 1,
   });
   const dehydrateState = dehydrate(queryClient);
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -87,6 +87,25 @@ export interface PackageResponseData {
   isWish: boolean;
 }
 
+export interface ScheduleInfo {
+  day: number;
+  schedule: string[];
+  breakfast: string;
+  lunch: string;
+  dinner: string;
+}
+
+export interface PackageReview {
+  reviewId: number;
+  content: string;
+  createdAt: string;
+  averageStars: number;
+  productScore: number;
+  scheduleScore: number;
+  guideScore: number;
+  appointmentScore: number;
+}
+
 // mypage
 export interface MyReview {
   packageId: number;

--- a/src/hooks/query/usePackageReveiwQuery.tsx
+++ b/src/hooks/query/usePackageReveiwQuery.tsx
@@ -1,0 +1,17 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import getPackageReveiws from "@/api/items/getPackageReviews";
+
+const usePackageReveiwQuery = (id: string) => {
+  return useInfiniteQuery({
+    queryKey: ["package-detail", "reviews"],
+    queryFn: ({ pageParam }) => getPackageReveiws(Number(id), pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      const page = lastPage.data.page.currentPage;
+      return page + 1;
+    },
+    refetchOnMount: false,
+  });
+};
+
+export default usePackageReveiwQuery;

--- a/src/hooks/query/usePackageScoreQuery.tsx
+++ b/src/hooks/query/usePackageScoreQuery.tsx
@@ -1,0 +1,13 @@
+import getPackageScore from "@/api/items/getPackageScore";
+import { useQuery } from "@tanstack/react-query";
+
+const usePackageScoreQuery = (id: string | string[]) => {
+  return useQuery({
+    queryKey: ["package-detail", "score"],
+    queryFn: async () => {
+      return getPackageScore(Number(id));
+    },
+  });
+};
+
+export default usePackageScoreQuery;

--- a/src/mocks/data/packageScheduleData.ts
+++ b/src/mocks/data/packageScheduleData.ts
@@ -1153,3 +1153,83 @@ export const packageSchedules = [
     dinner: "",
   },
 ];
+
+export const reviewSummary = {
+  count: 0,
+  averageStars: 4.8, // 0.0~5.0
+  averageProductScore: 4.2, // 상품정보 점수, 0~5
+  averageScheduleScore: 3.4, // 일정구성 점수, 0~5
+  averageGuideScore: 4.4, // 가이드 친절도 점수, 0~5
+  averageAppointmentScore: 5, // 가이드 시간/일정 준수 점수, 0~5
+};
+
+export const reviewList = {
+  data: [
+    {
+      reviewId: 0,
+      content: "오로지 우리 식구만의 첫 해외여행",
+      createdAt: "2010-01-01",
+      averageStars: 0.0,
+      productScore: 0,
+      scheduleScore: 0,
+      guideScore: 0,
+      appointmentScore: 0,
+    },
+    {
+      reviewId: 1,
+      content: "오로지 우리 식구만의 첫 해외여행",
+      createdAt: "2010-01-01",
+      averageStars: 0.0,
+      productScore: 0,
+      scheduleScore: 0,
+      guideScore: 0,
+      appointmentScore: 0,
+    },
+    {
+      reviewId: 2,
+      content: "오로지 우리 식구만의 첫 해외여행",
+      createdAt: "2010-01-01",
+      averageStars: 0.0,
+      productScore: 0,
+      scheduleScore: 0,
+      guideScore: 0,
+      appointmentScore: 0,
+    },
+    {
+      reviewId: 3,
+      content: "오로지 우리 식구만의 첫 해외여행",
+      createdAt: "2010-01-01",
+      averageStars: 0.0,
+      productScore: 0,
+      scheduleScore: 0,
+      guideScore: 0,
+      appointmentScore: 0,
+    },
+    {
+      reviewId: 4,
+      content: "오로지 우리 식구만의 첫 해외여행",
+      createdAt: "2010-01-01",
+      averageStars: 0.0,
+      productScore: 0,
+      scheduleScore: 0,
+      guideScore: 0,
+      appointmentScore: 0,
+    },
+    {
+      reviewId: 5,
+      content: "오로지 우리 식구만의 첫 해외여행",
+      createdAt: "2010-01-01",
+      averageStars: 0.0,
+      productScore: 0,
+      scheduleScore: 0,
+      guideScore: 0,
+      appointmentScore: 0,
+    },
+  ],
+  page: {
+    currentPage: 0, // 현재 페이지
+    totalPage: 0, // 끝 페이지
+    currentElements: 0, // 현재 보여지는 목록의 개수
+    totalElements: 0, // 모든 페이지를 통틀어 목록이 몇 개 있는지
+  },
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -417,6 +417,105 @@ const handlers = [
     });
   }),
 
+  // 패키지 리뷰
+  http.get("/v1/reviews/packages/:id/list", ({ request }) => {
+    const url = new URL(request.url);
+    const reviewPage = Number(url.searchParams.get("page")) || 1;
+
+    console.log(`${reviewPage} 페이지`);
+
+    return HttpResponse.json({
+      code: 200,
+      data: {
+        data: [
+          {
+            reviewId: reviewPage,
+            content: `오로지 우리 식구만의 첫 해외여행 ${reviewPage} 페이지`,
+            createdAt: "2010-01-01",
+            averageStars: 0.0,
+            productScore: 0,
+            scheduleScore: 0,
+            guideScore: 0,
+            appointmentScore: 0,
+          },
+          {
+            reviewId: reviewPage + 2,
+            content: `오로지 우리 식구만의 첫 해외여행 ${reviewPage} 페이지`,
+            createdAt: "2010-01-01",
+            averageStars: 0.0,
+            productScore: 0,
+            scheduleScore: 0,
+            guideScore: 0,
+            appointmentScore: 0,
+          },
+          {
+            reviewId: reviewPage + 3,
+            content: `오로지 우리 식구만의 첫 해외여행 ${reviewPage} 페이지`,
+            createdAt: "2010-01-01",
+            averageStars: 0.0,
+            productScore: 0,
+            scheduleScore: 0,
+            guideScore: 0,
+            appointmentScore: 0,
+          },
+          {
+            reviewId: reviewPage + 4,
+            content: `오로지 우리 식구만의 첫 해외여행 ${reviewPage} 페이지`,
+            createdAt: "2010-01-01",
+            averageStars: 0.0,
+            productScore: 0,
+            scheduleScore: 0,
+            guideScore: 0,
+            appointmentScore: 0,
+          },
+          {
+            reviewId: reviewPage + 5,
+            content: `오로지 우리 식구만의 첫 해외여행 ${reviewPage} 페이지`,
+            createdAt: "2010-01-01",
+            averageStars: 0.0,
+            productScore: 0,
+            scheduleScore: 0,
+            guideScore: 0,
+            appointmentScore: 0,
+          },
+          {
+            reviewId: reviewPage + 6,
+            content: `오로지 우리 식구만의 첫 해외여행 ${reviewPage} 페이지`,
+            createdAt: "2010-01-01",
+            averageStars: 0.0,
+            productScore: 0,
+            scheduleScore: 0,
+            guideScore: 0,
+            appointmentScore: 0,
+          },
+        ],
+        page: {
+          currentPage: reviewPage,
+          totalPage: 10,
+          currentElements: 6,
+          totalElements: 0,
+        },
+      },
+    });
+  }),
+
+  // 패키지 리뷰 평점
+  http.get("/v1/reviews/packages/:id/list/summary", async () => {
+    console.log("패키지 리뷰 평점");
+
+    return HttpResponse.json({
+      code: 200,
+      data: {
+        count: 0,
+        averageStars: 4.8,
+        averageProductScore: 4.2,
+        averageScheduleScore: 3.4,
+        averageGuideScore: 4.4,
+        averageAppointmentScore: 5,
+      },
+    });
+  }),
+
   // 내 정보 조회
   http.get("/v1/my/info", async () => {
     console.log("내 정보 조회");

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -70,6 +70,7 @@ const config: Config = {
       backgroundImage: {
         "gradient-white":
           "linear-gradient(0deg, rgba(255,255,255,1) 5%, rgba(255,255,255,0) 100%)",
+        "gradient-red": "linear-gradient(270deg, #FF3D73 2.25%, #FF758A 100%);",
       },
       keyframes: {
         // 약관 동의 애니메이션


### PR DESCRIPTION
## 구현 내용
- 패키지 리뷰 목록을 추가했습니다.
- 무한 스크롤을 통해 데이터를 가져올 수 있도록 하였습니다.

![스크린샷 2024-01-18 161622](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/47518a22-9c15-4c1f-894b-16fe3b561352)

## 기타
- 리뷰 아이템은 기존 마이 페이지에 있는 기본 틀을 그대로 가져다 따로 컴포넌트로 만들었습니다. 거의 똑같은 거라 공통으로 그냥 쓰면 되지만 함부로 수정했다가 마이 페이지의 레이아웃이 망가질까 봐 일단 따로 다시 만들었고, 이후 리팩토링 과정에서 합치면 좋을 거 같습니다.

## 이슈번호
연결된 이슈가 있을 때만 작성해 주세요!
