### PR TITLE
Feat: 리뷰 없을 때 화면 추가

### DIFF
--- a/src/app/(non-navbar)/items/[id]/_component/NoReviews.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/NoReviews.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import DetailTypography from "./DetailTypography";
+
+const NoReviews = () => {
+  return (
+    <div className="w-full">
+      <div className="mt-10">
+        <div className="flex justify-center mb-6">
+          <img src="/assets/withdraw.png" alt="메인 로고" className="w-40" />
+        </div>
+        <DetailTypography variant="h1" color={4} size={16} align="center">
+          해당 상품의 리뷰가 없습니다
+        </DetailTypography>
+        <DetailTypography color={6} size={14} align="center">
+          리뷰를 작성해 보세요!!
+        </DetailTypography>
+        <div className="flex justify-center mt-1">
+          <Link
+            href={"/"}
+            className="border-[1px] border-solid border-pink text-pink rounded-[6px] px-2 py-1 m-2"
+          >
+            리뷰 작성하러 가기
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NoReviews;

--- a/src/app/(non-navbar)/items/[id]/_component/Reviews.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/Reviews.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from "react";
 import DetailTypography from "./DetailTypography";
 import ReviewItem from "./ReviewItem";
 import ReviewRangeList from "./ReviewRangeList";
+import NoReviews from "./NoReviews";
 
 const Reviews = () => {
   const params = useParams();
@@ -16,7 +17,7 @@ const Reviews = () => {
     isFetching,
   } = usePackageReveiwQuery(params.id as string);
   const { data: score } = usePackageScoreQuery(params.id as string);
-  console.log(score);
+  console.log(reviews?.pages[0].data.data);
 
   const boxRef = useRef(null);
 
@@ -45,6 +46,10 @@ const Reviews = () => {
       }
     };
   }, [isFetching, hasNextPage, fetchNextPage]);
+
+  if (reviews?.pages[0].data.data.length === 0) {
+    return <NoReviews />;
+  }
 
   return (
     <div className="mt-6">


### PR DESCRIPTION
## 구현 내용
- 배포 환경에서 리뷰가 없으면 무한으로 요청 보내지는 현상으로 인해 리뷰 없을 때 화면을 추가했습니다.

![스크린샷 2024-01-19 114717](https://github.com/yanolja-finalproject/LETS_FE/assets/125336070/79e760bc-502f-4abc-a3f0-a63e4f229627)



## 기타
- 이후 로그인 되어 있으면 마이 페이지 아니면 로그인 페이지로 이동 되도록 만들 예정입니다.
- 해당 404 컴포넌트를 text로 받아서 공통으로 사용하는 부분은 이후에 고려해보겠습니다.

## 이슈번호
X
