### PR TITLE
Feat: 상세 페이지 로그인 유저 구분, 탭 컴포넌트 스크롤 속성 추가

### DIFF
--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -127,6 +127,7 @@ const DetailMain = () => {
             selectedClass: "py-1 text-black  border-b-2 border-pink",
           }}
           sticky
+          scroll
         />
       </div>
       <ItemDetailBottom

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -30,7 +30,7 @@ const DetailMain = () => {
   );
   const [viewMore, setViewMore] = useState(false);
   // 이후 로그인 유저 구분
-  const [, setIsLogin] = useState(false);
+  // const [, setIsLogin] = useState(false);
 
   if (packageDetail.code === 404) {
     return <ItemNotFound />;
@@ -133,7 +133,7 @@ const DetailMain = () => {
       <ItemDetailBottom
         viewMore={viewMore}
         setViewMore={setViewMore}
-        setIsLogin={setIsLogin}
+        // setIsLogin={setIsLogin}
         packageDetail={packageDetail.data}
       />
       <ScrollToUpButton />

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -59,7 +59,7 @@ const DetailMain = () => {
     },
     {
       name: "리뷰",
-      content: <Reviews user={packageDetail.data.myInfo.username} />,
+      content: <Reviews user={packageDetail.data.myInfo?.username} />,
     },
   ];
 

--- a/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/DetailMain.tsx
@@ -18,6 +18,7 @@ import PackageTagBadge from "./PackageTagBadge";
 import Reviews from "./Reviews";
 import ScheduleDetail from "./ScheduleDetail";
 import TravelDate from "./TravelDate";
+// import Dialog from "@/app/_component/common/layout/Dialog";
 
 const DetailMain = () => {
   const params = useParams();
@@ -28,6 +29,8 @@ const DetailMain = () => {
     searchParams.get("departDate"),
   );
   const [viewMore, setViewMore] = useState(false);
+  // 이후 로그인 유저 구분
+  const [, setIsLogin] = useState(false);
 
   if (packageDetail.code === 404) {
     return <ItemNotFound />;
@@ -54,7 +57,10 @@ const DetailMain = () => {
         />
       ),
     },
-    { name: "리뷰", content: <Reviews /> },
+    {
+      name: "리뷰",
+      content: <Reviews user={packageDetail.data.myInfo.username} />,
+    },
   ];
 
   return (
@@ -63,6 +69,18 @@ const DetailMain = () => {
         viewMore ? "pb-[80px]" : "h-[700px] web:h-[630px]"
       } relative`}
     >
+      {/* 이후 로그인 유저 구분 */}
+      {/* <Dialog
+        isOpen={isLogin}
+        type="confirm"
+        theme="login"
+        onClose={() => {
+          setIsLogin(false);
+        }}
+        onConfirm={() => {
+          router.push("/signin");
+        }}
+      /> */}
       <DetailSwiper imgUrls={packageDetail.data.imageUrls} />
       <div className="px-8">
         <BadgeList>
@@ -114,6 +132,7 @@ const DetailMain = () => {
       <ItemDetailBottom
         viewMore={viewMore}
         setViewMore={setViewMore}
+        setIsLogin={setIsLogin}
         packageDetail={packageDetail.data}
       />
       <ScrollToUpButton />

--- a/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
@@ -15,10 +15,16 @@ import StorePerson from "./StorePerson";
 interface Props {
   viewMore: boolean;
   setViewMore: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLogin: React.Dispatch<React.SetStateAction<boolean>>;
   packageDetail: PackageResponseData;
 }
 
-const ItemDetailBottom = ({ viewMore, setViewMore, packageDetail }: Props) => {
+const ItemDetailBottom = ({
+  viewMore,
+  setViewMore,
+  setIsLogin,
+  packageDetail,
+}: Props) => {
   const isScrollUp = useScrollUp();
   const paymentStore = usePaymentStore();
   const router = useRouter();
@@ -32,6 +38,8 @@ const ItemDetailBottom = ({ viewMore, setViewMore, packageDetail }: Props) => {
 
   const [totalPrice, setTotalPrice] = useState(packageDetail.totalPrice.adult);
 
+  // console.log(packageDetail.myInfo);
+
   useEffect(() => {
     setPortalElement(document.getElementById("portal"));
   }, [reservation]);
@@ -44,6 +52,10 @@ const ItemDetailBottom = ({ viewMore, setViewMore, packageDetail }: Props) => {
   };
 
   const handlePayment = () => {
+    if (packageDetail.myInfo.username === "") {
+      setIsLogin(true);
+    }
+    // 이후 로그인 유저 구분
     const newDepartureDate = packageDetail.departureDatetime.date.split("-");
     const newEndDate = packageDetail.endDatetime.date.split("-");
     paymentStore.setPaymentData({

--- a/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/ItemDetailBottom.tsx
@@ -15,16 +15,11 @@ import StorePerson from "./StorePerson";
 interface Props {
   viewMore: boolean;
   setViewMore: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsLogin: React.Dispatch<React.SetStateAction<boolean>>;
+  // setIsLogin: React.Dispatch<React.SetStateAction<boolean>>;
   packageDetail: PackageResponseData;
 }
 
-const ItemDetailBottom = ({
-  viewMore,
-  setViewMore,
-  setIsLogin,
-  packageDetail,
-}: Props) => {
+const ItemDetailBottom = ({ viewMore, setViewMore, packageDetail }: Props) => {
   const isScrollUp = useScrollUp();
   const paymentStore = usePaymentStore();
   const router = useRouter();
@@ -52,9 +47,9 @@ const ItemDetailBottom = ({
   };
 
   const handlePayment = () => {
-    if (packageDetail.myInfo.username === "") {
-      setIsLogin(true);
-    }
+    // if (!packageDetail.myInfo) {
+    //   setIsLogin(true);
+    // }
     // 이후 로그인 유저 구분
     const newDepartureDate = packageDetail.departureDatetime.date.split("-");
     const newEndDate = packageDetail.endDatetime.date.split("-");

--- a/src/app/(non-navbar)/items/[id]/_component/NoReviews.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/NoReviews.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
 import DetailTypography from "./DetailTypography";
 
-const NoReviews = () => {
+interface Props {
+  user: string;
+}
+
+const NoReviews = ({ user }: Props) => {
   return (
     <div className="w-full">
       <div className="mt-10">
@@ -16,7 +20,7 @@ const NoReviews = () => {
         </DetailTypography>
         <div className="flex justify-center mt-1">
           <Link
-            href={"/"}
+            href={user === "" ? "/" : "/my"}
             className="border-[1px] border-solid border-pink text-pink rounded-[6px] px-2 py-1 m-2"
           >
             리뷰 작성하러 가기

--- a/src/app/(non-navbar)/items/[id]/_component/Reviews.tsx
+++ b/src/app/(non-navbar)/items/[id]/_component/Reviews.tsx
@@ -8,7 +8,11 @@ import ReviewItem from "./ReviewItem";
 import ReviewRangeList from "./ReviewRangeList";
 import NoReviews from "./NoReviews";
 
-const Reviews = () => {
+interface Props {
+  user: string;
+}
+
+const Reviews = ({ user }: Props) => {
   const params = useParams();
   const {
     data: reviews,
@@ -17,7 +21,6 @@ const Reviews = () => {
     isFetching,
   } = usePackageReveiwQuery(params.id as string);
   const { data: score } = usePackageScoreQuery(params.id as string);
-  console.log(reviews?.pages[0].data.data);
 
   const boxRef = useRef(null);
 
@@ -48,7 +51,7 @@ const Reviews = () => {
   }, [isFetching, hasNextPage, fetchNextPage]);
 
   if (reviews?.pages[0].data.data.length === 0) {
-    return <NoReviews />;
+    return <NoReviews user={user} />;
   }
 
   return (

--- a/src/app/_component/common/layout/Dialog.tsx
+++ b/src/app/_component/common/layout/Dialog.tsx
@@ -33,10 +33,10 @@ const Dialog = ({
 
   return (
     <>
-      <div className="z-[1000] fixed top-0 left-0 w-full h-full  bg-black/60 cursor-pointer" />
+      <div className="z-[500] fixed top-0 left-0 w-full h-full  bg-black/60 cursor-pointer" />
       {type === "confirm" && (
         <dialog
-          className="z-[1100] w-[87.2%] web:w-[327px] h-[176px] mx-auto absolute top-[30%] rounded-md bg-white flex flex-col justify-evenly shadow-md "
+          className="z-[550] w-[87.2%] web:w-[327px] h-[176px] mx-auto absolute top-[30%] rounded-md bg-white flex flex-col justify-evenly shadow-md "
           ref={ref}
         >
           {theme === "withdraw" && (

--- a/src/app/_component/common/layout/Dialog.tsx
+++ b/src/app/_component/common/layout/Dialog.tsx
@@ -33,10 +33,10 @@ const Dialog = ({
 
   return (
     <>
-      <div className="z-5 fixed top-0 left-0 w-full h-full  bg-black/60 cursor-pointer" />
+      <div className="z-[1000] fixed top-0 left-0 w-full h-full  bg-black/60 cursor-pointer" />
       {type === "confirm" && (
         <dialog
-          className="z-10 w-[87.2%] web:w-[327px] h-[176px] mx-auto absolute top-[30%] rounded-md bg-white flex flex-col justify-evenly shadow-md "
+          className="z-[1100] w-[87.2%] web:w-[327px] h-[176px] mx-auto absolute top-[30%] rounded-md bg-white flex flex-col justify-evenly shadow-md "
           ref={ref}
         >
           {theme === "withdraw" && (

--- a/src/app/_component/common/layout/TabsContainer.tsx
+++ b/src/app/_component/common/layout/TabsContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Tab from "@/app/_component/common/atom/Tab";
 import TabButton from "@/app/_component/common/atom/TabButton";
 
@@ -14,16 +14,35 @@ interface Props {
     selectedClass?: string;
   };
   sticky?: boolean;
+  scroll?: boolean;
 }
 
-const TabsContainer = ({ tabs, tabButtonStyle, sticky = false }: Props) => {
+const TabsContainer = ({
+  tabs,
+  tabButtonStyle,
+  sticky = false,
+  scroll = false,
+}: Props) => {
   const [selectedTab, setSelectedTab] = useState<string>(tabs[0].name);
+  const boxRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  useEffect(() => {
+    if (boxRef.current) {
+      const rect = boxRef.current.getBoundingClientRect();
+      setScrollTop(rect.y);
+    }
+  }, []);
 
   const handleSelect = (tabName: string) => {
     setSelectedTab(tabName);
+    if (scroll && window.scrollY > scrollTop) {
+      window.scrollTo({ top: scrollTop, behavior: "smooth" });
+    }
   };
+
   return (
-    <article>
+    <article ref={boxRef}>
       <Tab
         buttons={tabs.map((tab) => (
           <TabButton


### PR DESCRIPTION
## 구현 내용
- 상세 페이지에서 로그인 유저가 구분되도록 하였습니다.
- 탭 컴포넌트에서 scroll속성을 주면 (기본값 false) 스크롤이 해당 탭보다 아래로 내려가 있을 때 탭을 클릭하면 스크롤이 탭 위치까지 이동됩니다.

## 기타
- 상세 페이지의 주석된 부분을 활성화하면 실제 로그인 유저에 대한 구분을 합니다. 이 부분은 로그인 오류 해결 후 다시 활성화할 예정입니다.

## 이슈번호
X
