### PR TITLE
Env: 로컬 환경 커스텀 https서버 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "server": "node server.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,27 @@
+const https = require("https");
+const { parse } = require("url");
+const next = require("next");
+const fs = require("fs");
+
+const dev = process.env.NODE_ENV !== "production";
+const PORT = 3000;
+const hostname = "local.winnerone.site";
+const app = next({ dev, hostname, PORT });
+const handle = app.getRequestHandler();
+
+const httpsOptions = {
+  key: fs.readFileSync("local.key.pem", "utf8"),
+  cert: fs.readFileSync("local.cert.pem", "utf8"),
+};
+
+app.prepare().then(() => {
+  https
+    .createServer(httpsOptions, (req, res) => {
+      const parsedUrl = parse(req.url, true);
+      handle(req, res, parsedUrl);
+    })
+    .listen(PORT, (err) => {
+      if (err) throw err;
+      console.log(`> Ready on https://${hostname}:${PORT}`);
+    });
+});


### PR DESCRIPTION
## 구현 내용
- 로컬에서 https로 서버가 돌아갈 수 있도록 커스텀 서버를 추가 하였습니다. 
- localhost도메인 이름을 다른 이름으로 실행시키는 방법이랑 가짜 인증서 받는 방법 위키에 적어 놨습니다.
[wiki링크
](https://github.com/yanolja-finalproject/LETS_FE/wiki/next.js-%EC%84%9C%EB%B2%84-https%EB%A1%9C-%EC%8B%A4%ED%96%89%EC%8B%9C%ED%82%A4%EA%B8%B0)