### PR TITLE
Feat: 예약내역 무한스크롤

### DIFF
--- a/src/api/my/getMyInfo.ts
+++ b/src/api/my/getMyInfo.ts
@@ -7,7 +7,7 @@ const getMyInfo = async () => {
       },
     );
     const res = await result.json();
-    return res;
+    return res.data;
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/api/my/getMyOrders.ts
+++ b/src/api/my/getMyOrders.ts
@@ -8,7 +8,7 @@ const getMyOrders = async (page: number, pageSize: number) => {
     );
     const res = await result.json();
     console.log("order-data:", res);
-    return res.data;
+    return res;
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/api/my/getMyUpcomingPackage.ts
+++ b/src/api/my/getMyUpcomingPackage.ts
@@ -2,11 +2,15 @@ const getMyUpcomingPackage = async () => {
   try {
     const result = await fetch(
       `${process.env.NEXT_PUBLIC_BASE_URL}/v1/my/upcoming-package`,
-      {
-        credentials: "include",
-      },
+      { credentials: "include" },
     );
     const res = await result.json();
+    console.log("다가오는 패키지", res);
+
+    if (!result.ok) {
+      throw new Error(res.error || "API 호출에 실패했습니다.");
+    }
+
     return res.data;
   } catch (error) {
     console.error(error);

--- a/src/api/my/getMyUpcomingPackage.ts
+++ b/src/api/my/getMyUpcomingPackage.ts
@@ -7,7 +7,7 @@ const getMyUpcomingPackage = async () => {
       },
     );
     const res = await result.json();
-    return res;
+    return res.data;
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/app/(navbar)/my/_component/UpcomingPackage.tsx
+++ b/src/app/(navbar)/my/_component/UpcomingPackage.tsx
@@ -5,7 +5,7 @@ import useMyUpcomingPackageQuery from "@/hooks/query/useMyUpcomingPackageQuery";
 import { TITLE_CLASS } from "@/app/constants";
 import Chip from "./Chip";
 
-const UpcomingPackages = () => {
+const UpcomingPackage = () => {
   const { data, isLoading, isError, error } = useMyUpcomingPackageQuery();
 
   if (isLoading) return <div>로딩 중...</div>;
@@ -43,4 +43,4 @@ const UpcomingPackages = () => {
   );
 };
 
-export default UpcomingPackages;
+export default UpcomingPackage;

--- a/src/app/(navbar)/my/_component/UpcomingPackages.tsx
+++ b/src/app/(navbar)/my/_component/UpcomingPackages.tsx
@@ -15,11 +15,7 @@ const UpcomingPackages = () => {
       <h2 className={TITLE_CLASS}>다가오는 패키지가 있어요!</h2>
       <div className="flex flex-wrap relative gap-[18px]">
         <div className=" w-[90px] rounded-md overflow-hidden">
-          <img
-            className="w-full h-full"
-            src="//source.unsplash.com/66x66?osaka"
-            alt="다가오는 패키지"
-          />
+          <img className="w-full h-full" src={data.imageUrl} alt={data.title} />
         </div>
         <div className=" flex w-2/3  justify-between items-center">
           <div className="flex flex-col justify-center gap-1 overflow-hidden">

--- a/src/app/(navbar)/my/menu/_component/DataListItem.tsx
+++ b/src/app/(navbar)/my/menu/_component/DataListItem.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 const DataListItem = ({ data, theme = "notice" }: Props) => {
   const listTitleClass =
-    "w-full flex p-4 rounded-[10px] bg-grey-e flex-col gap-2 items-between justify-center bg-opacity-20 max-h-[84px]";
+    "w-full flex p-4 rounded-[10px] bg-grey-e flex-col gap-2 items-between justify-center bg-opacity-20";
 
   return (
     <li className={listTitleClass}>

--- a/src/app/(navbar)/my/menu/reservation/page.tsx
+++ b/src/app/(navbar)/my/menu/reservation/page.tsx
@@ -1,8 +1,36 @@
+"use client";
+
+import useMyOrdersQuery from "@/hooks/query/useMyOrdersQuery";
+import { MyOrder } from "@/app/types";
+import useInfiniteScroll from "@/hooks/useInfiniteScroll";
 import InnerSection from "../../_component/InnerSection";
 import ReservationItem from "../../_component/ReservationItem";
 
-// TODO:: 여백 색상 상세 디자인 확정 시 작업
+const pageSize = 10;
+
 const ReservationPage = () => {
+  const {
+    data: orderData,
+    isFetching,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+  } = useMyOrdersQuery(pageSize, "detail");
+
+  const lastElementRef = useInfiniteScroll(
+    fetchNextPage,
+    isFetching,
+    hasNextPage,
+  );
+
+  const totalCount = orderData?.pages[0]?.page?.totalElements ?? 0;
+
+  console.log("orderData:", orderData);
+
+  if (isFetching) return <div>로딩 중...</div>;
+  if (isError) return <div>⚠ {error.message} ⚠</div>;
+
   return (
     <InnerSection
       text="예약 내역"
@@ -12,11 +40,23 @@ const ReservationPage = () => {
       iconAlt="메뉴 아이콘"
     >
       <h2 className="font-bold text-black-2 text-lg mb-8">
-        총 <span className="text-pink-main ">N</span>
+        총<span className="text-pink-main ">{totalCount}</span>
         개의 패키지 상품
       </h2>
       <ul>
-        <ReservationItem theme="reservationMenu" hashTag />
+        {orderData?.pages.map((page) =>
+          page.data.map((order: MyOrder) => (
+            <ReservationItem
+              key={order.orderCode}
+              orderData={order.package}
+              theme="reservationMenu"
+              hashTag
+            />
+          )),
+        )}
+        <li ref={lastElementRef} className="w-full h-20 list-none">
+          {isFetching && <div>loading..🎈</div>}
+        </li>
       </ul>
     </InnerSection>
   );

--- a/src/app/(navbar)/my/page.tsx
+++ b/src/app/(navbar)/my/page.tsx
@@ -3,7 +3,7 @@ import BottomNav from "@/app/_component/common/layout/BottomNav";
 import ReservationTabContent from "./_component/ReservationTabContent";
 import MyReviewTabContent from "./_component/MyReviewTabContent";
 import UserInfo from "./_component/UserInfo";
-import UpcomingPackages from "./_component/UpcomingPackages";
+import UpcomingPackage from "./_component/UpcomingPackage";
 import InnerSection from "./_component/InnerSection";
 
 export function generateMetadata() {
@@ -25,7 +25,7 @@ const MyPage = async () => {
       iconAlt="메뉴 아이콘"
     >
       <UserInfo showEditIcon />
-      <UpcomingPackages />
+      <UpcomingPackage />
       <TabsContainer
         tabs={tabsData}
         tabButtonStyle={{

--- a/src/hooks/query/useMyOrdersQuery.ts
+++ b/src/hooks/query/useMyOrdersQuery.ts
@@ -1,10 +1,24 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
 import getMyOrders from "@/api/my/getMyOrders";
-import { useQuery } from "@tanstack/react-query";
 
-const useMyOrdersQuery = (page: number, pageSize: number) => {
-  return useQuery({
-    queryKey: ["myOrders", page, pageSize],
-    queryFn: () => getMyOrders(page, pageSize),
+const useMyOrdersQuery = (pageSize: number, queryKey: string) => {
+  return useInfiniteQuery({
+    queryKey: ["myOrders", queryKey],
+    queryFn: ({ pageParam }) => getMyOrders(pageParam, pageSize),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (
+        lastPage &&
+        lastPage.page &&
+        lastPage.page.currentPage < lastPage.page.totalPage
+      ) {
+        return lastPage.page.currentPage + 1;
+      }
+      return undefined;
+    },
+
+    refetchOnMount: false,
   });
 };
+
 export default useMyOrdersQuery;

--- a/src/hooks/query/useMyUpcomingPackageQuery.ts
+++ b/src/hooks/query/useMyUpcomingPackageQuery.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 
 const useMyUpcomingPackageQuery = () => {
   return useQuery({
-    queryKey: ["upcomingPackages"],
+    queryKey: ["upcomingPackage"],
     queryFn: getMyUpcomingPackage,
   });
 };

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+
+const useInfiniteScroll = (
+  fetchNextPage: () => void,
+  isFetching: boolean,
+  hasNextPage: boolean,
+) => {
+  const lastElementRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry.isIntersecting && !isFetching && hasNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.2 },
+    );
+
+    const currentRef = lastElementRef.current;
+    if (currentRef) {
+      observer.observe(currentRef);
+    }
+
+    return () => {
+      if (currentRef) {
+        observer.unobserve(currentRef);
+      }
+    };
+  }, [fetchNextPage, isFetching, hasNextPage]);
+
+  return lastElementRef;
+};
+
+export default useInfiniteScroll;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -615,26 +615,33 @@ const handlers = [
   // 내 정보 조회
   http.get("/v1/my/info", async () => {
     const myInfo = {
-      email: "user@example.com",
-      username: "홍길동",
-      phone: "010-1234-5678",
-      addr1: "서울특별시 강남구",
-      addr2: "역삼동 123-45",
-      postCode: "06178",
+      code: 200,
+      data: {
+        email: "user@example.com",
+        username: "위너원",
+        phone: "010-1234-5678",
+        addr1: "Gangnam-gu, Seoul",
+        addr2: "123-45 Yeoksam-dong",
+        postCode: "06178",
+      },
     };
+
     return HttpResponse.json(myInfo);
   }),
 
   // 다가오는 패키지
   http.get("/v1/my/upcoming-package", async () => {
     const upComingPackage = {
-      packageId: 0,
-      imageUrl: "//source.unsplash.com/500x500?america",
-      title: "오사카 특별 패키지",
-      dday: 30,
-      nationName: "일본",
-      departureDate: "2024-02-01",
-      endDate: "2024-02-05",
+      code: 200,
+      data: {
+        packageId: 0,
+        imageUrl: "//source.unsplash.com/500x500?america",
+        title: "오사카 특별 패키지",
+        dday: 30,
+        nationName: "일본",
+        departureDate: "2024-02-01",
+        endDate: "2024-02-05",
+      },
     };
     return HttpResponse.json(upComingPackage);
   }),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -666,69 +666,236 @@ const handlers = [
     });
   }),
 
-  // 예약내역
-  http.get("/v1/orders", async () => {
-    const myOrders = {
-      data: [
-        {
-          orderCode: "2023122910352",
-          availableDateId: 0,
-          package: {
-            packageId: 1,
-            imageUrl: "//source.unsplash.com/90x90?japan",
-            nationName: "일본",
-            title: "청룡의 해 얼리버드 특가1",
-            hashtags: ["일본", "체험", "로컬 다이닝"],
-            lodgeDays: 1, // 1박
-            tripDays: 2, // 2일
-            travelPeriod: "24.02.01~24.02.05",
-            isWish: false,
-            reviewed: false, // 리뷰 작성 여부
-          },
+  http.get("/v1/orders", ({ request }) => {
+    const url = new URL(request.url);
+    const orderPage = Number(url.searchParams.get("page")) || 1;
+    const pageSize = Number(url.searchParams.get("pageSize")) || 3;
+    const orderData = [
+      {
+        orderCode: "2023122910351",
+        availableDateId: 0,
+        package: {
+          packageId: 0,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가0`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
         },
-
-        {
-          orderCode: "2023123010352",
-          availableDateId: 0,
-          package: {
-            packageId: 2,
-            imageUrl: "//source.unsplash.com/90x90?japan",
-            nationName: "일본",
-            title: "청룡의 해 얼리버드 특가2",
-            hashtags: ["일본", "체험/액티비티", "로컬 다이닝"],
-            lodgeDays: 1, // 1박
-            tripDays: 2, // 2일
-            travelPeriod: "24.02.01~24.02.05",
-            isWish: false,
-            reviewed: false, // 리뷰 작성 여부
-          },
-        },
-        {
-          orderCode: "2024122910352",
-          availableDateId: 0,
-          package: {
-            packageId: 3,
-            imageUrl: "//source.unsplash.com/90x90?japan",
-            nationName: "일본",
-            title: "청룡의 해 얼리버드 특가3",
-            hashtags: ["일본", "체험", "로컬 다이닝"],
-            lodgeDays: 1, // 1박
-            tripDays: 2, // 2일
-            travelPeriod: "24.02.01~24.02.05",
-            isWish: false,
-            reviewed: false, // 리뷰 작성 여부
-          },
-        },
-      ],
-      page: {
-        currentPage: 0, // 현재 페이지
-        totalPage: 0, // 끝 페이지
-        currentElements: 0, // 현재 보여지는 목록의 개수
-        totalElements: 0, // 모든 페이지를 통틀어 목록이 몇 개 있는지
       },
-    };
 
-    return HttpResponse.json(myOrders);
+      {
+        orderCode: "2023123010351",
+        availableDateId: 0,
+        package: {
+          packageId: 1,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가1`,
+          hashtags: ["일본", "체험/액티비티", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2024122910352",
+        availableDateId: 0,
+        package: {
+          packageId: 2,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가2`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910353",
+        availableDateId: 0,
+        package: {
+          packageId: 3,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가3`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910354",
+        availableDateId: 0,
+        package: {
+          packageId: 4,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가4`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910355",
+        availableDateId: 0,
+        package: {
+          packageId: 5,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가5`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910356",
+        availableDateId: 0,
+        package: {
+          packageId: 6,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가6`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910357",
+        availableDateId: 0,
+        package: {
+          packageId: 7,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가7`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910358",
+        availableDateId: 0,
+        package: {
+          packageId: 8,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가8`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910359",
+        availableDateId: 0,
+        package: {
+          packageId: 9,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가9`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910310",
+        availableDateId: 0,
+        package: {
+          packageId: 10,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가10`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910311",
+        availableDateId: 0,
+        package: {
+          packageId: 11,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가11`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+      {
+        orderCode: "2023122910312",
+        availableDateId: 0,
+        package: {
+          packageId: 12,
+          imageUrl: "//source.unsplash.com/90x90?japan",
+          nationName: "일본",
+          title: `${orderPage}청룡의 해 얼리버드 특가12`,
+          hashtags: ["일본", "체험", "로컬 다이닝"],
+          lodgeDays: 1, // 1박
+          tripDays: 2, // 2일
+          travelPeriod: "24.02.01~24.02.05",
+          isWish: false,
+          reviewed: false, // 리뷰 작성 여부
+        },
+      },
+    ];
+    // 페이지 사이즈에 따라 데이터 필터링
+    const startIndex = (orderPage - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const filteredData = orderData.slice(startIndex, endIndex);
+
+    return HttpResponse.json({
+      code: 200,
+      data: filteredData,
+      page: {
+        currentPage: orderPage, // 현재 페이지
+        totalPage: Math.ceil(orderData.length / pageSize),
+        currentElements: pageSize, // 현재 보여지는 목록의 개수
+        totalElements: orderData.length, // 모든 페이지를 통틀어 목록이 몇 개 있는지
+      },
+    });
   }),
 
   // 공지사항 글 목록


### PR DESCRIPTION
## 구현 내용
- mock데이터 응답구조 및 api return값 수정
## 기타
mock데이터에 응답구조가 잘못들어가서 로컬에선 정상노출됐지만 배포사이트에서 노출되지 않는 점 확인하고 수정하였습니다!
+) 마이페이지 탭 영역 예약내역 무한스크롤
+) 마이페이지 -> 메뉴 -> 예약내역 무한 스크롤

## 이슈번호
연결된 이슈가 있을 때만 작성해 주세요!
