### PR TITLE
Feat: 200_광고구좌페이지 퍼블리싱

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,18 @@ const nextConfig = {
         protocol: "https",
         hostname: "i.pinimg.com",
       },
+      {
+        protocol: "https",
+        hostname: "tourimage.interpark.com",
+      },
+      {
+        protocol: "https",
+        hostname: "openimage.interpark.com",
+      },
+      {
+        protocol: "https",
+        hostname: "media.interparkcdn.net",
+      },
     ],
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // 도메인 배열 중 첫번째는 테스트 이미지용으로 가져온 외부 주소입니다! 기능 구체화하면서 삭제 예정입니다.
   images: {
-    domains: [
-      "images.theconversation.com",
-      "api.winnerone.site",
-      "i.pinimg.com",
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.postimg.cc",
+      },
+      {
+        protocol: "https",
+        hostname: "i.pinimg.com",
+      },
     ],
   },
 };

--- a/src/api/advertisement/getAdvertisementInfo.ts
+++ b/src/api/advertisement/getAdvertisementInfo.ts
@@ -1,0 +1,14 @@
+const getAdvertisementInfo = async (id: number) => {
+  try {
+    const result = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/v1/advertisements/${id}`,
+    );
+    const res = await result.json();
+    return res.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default getAdvertisementInfo;

--- a/src/app/(non-navbar)/advertisement/[id]/_component/AdvertisementInfomation.tsx
+++ b/src/app/(non-navbar)/advertisement/[id]/_component/AdvertisementInfomation.tsx
@@ -1,15 +1,57 @@
 "use client";
 
 import useAdvertisementInfoQuery from "@/hooks/query/useAdvertisementInfoQuery";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface Props {
+  packageId: number;
+  imageUrl: string;
+  title: string;
+  transportation: string;
+  minPrice: number;
+}
 
 const AdvertisementInfomation = () => {
   const params = useParams();
+  const router = useRouter();
+  const [, setAdsPackage] = useState([]);
+  // 광고 슬라이드 선택으로 넘어온 id 값을 통해 어느 광고인지 확인 후 데이터 받아옴
+  const { data } = useAdvertisementInfoQuery(params.id);
 
-  const { data: advertisementInfo } = useAdvertisementInfoQuery(params.id);
+  // 각 광고(오사카, 대만, 유럽)에 대한 adId, name, packages 데이터 세팅
+  useEffect(() => {
+    if (data) {
+      setAdsPackage(data);
+    }
+    console.log(data);
+  }, [data]);
 
-  console.log(advertisementInfo);
-  return <div>123</div>;
+  return (
+    <div className="w-full px-6 grid grid-cols-2 grid-rows-2 gap-[17px]">
+      {data.packages.map((singlePackage: Props) => (
+        <div
+          key={`package-${singlePackage.packageId}`}
+          className="w-full h-auto flex-col relative"
+          onClick={() => router.push(`/items/${singlePackage.packageId}`)} // 상세 페이지 연결
+        >
+          <img
+            src={singlePackage.imageUrl}
+            alt="packageImg"
+            className="w-[155px] h-[180px] web:w-full mb-2 rounded-lg"
+          />
+          <div className="flex flex-col gap-[14px]">
+            <p className="w-[148px] h-[30px] web:w-full text-black-6 text-xs font-normal overflow-hidden">
+              {singlePackage.title}
+            </p>
+            <p className="text-black text-base font-bold">
+              {`${singlePackage.minPrice.toLocaleString()}원`}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 };
 
 export default AdvertisementInfomation;

--- a/src/app/(non-navbar)/advertisement/[id]/_component/AdvertisementInfomation.tsx
+++ b/src/app/(non-navbar)/advertisement/[id]/_component/AdvertisementInfomation.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import useAdvertisementInfoQuery from "@/hooks/query/useAdvertisementInfoQuery";
+import { useParams } from "next/navigation";
+
+const AdvertisementInfomation = () => {
+  const params = useParams();
+
+  const { data: advertisementInfo } = useAdvertisementInfoQuery(params.id);
+
+  console.log(advertisementInfo);
+  return <div>123</div>;
+};
+
+export default AdvertisementInfomation;

--- a/src/app/(non-navbar)/advertisement/[id]/page.tsx
+++ b/src/app/(non-navbar)/advertisement/[id]/page.tsx
@@ -23,7 +23,7 @@ const AdvertisementPage = async ({ params }: { params: { id: string } }) => {
     <section className="w-full flex flex-col items-center">
       {/* adId를 기반으로 헤더 텍스트 전달 */}
       <DefaultHeader text={`${getAdsHeaderText(Number(params.id))} 특별여행`} />
-      <HomeAdvertisements />
+      <HomeAdvertisements isDetail />
       <HydrationBoundary state={dehydrateState}>
         <AdvertisementInfomation />
       </HydrationBoundary>

--- a/src/app/(non-navbar)/advertisement/[id]/page.tsx
+++ b/src/app/(non-navbar)/advertisement/[id]/page.tsx
@@ -5,6 +5,8 @@ import {
   dehydrate,
 } from "@tanstack/react-query";
 import getAdvertisementInfo from "@/api/advertisement/getAdvertisementInfo";
+import HomeAdvertisements from "@/app/_component/home/HomeAdvertisements";
+import getAdsHeaderText from "@/utils/getAdsHeaderText";
 import AdvertisementInfomation from "./_component/AdvertisementInfomation";
 
 const AdvertisementPage = async ({ params }: { params: { id: string } }) => {
@@ -16,9 +18,12 @@ const AdvertisementPage = async ({ params }: { params: { id: string } }) => {
     },
   });
   const dehydrateState = dehydrate(queryClient);
+
   return (
     <section className="w-full flex flex-col items-center">
-      <DefaultHeader theme="default" text="hi" />
+      {/* adId를 기반으로 헤더 텍스트 전달 */}
+      <DefaultHeader text={`${getAdsHeaderText(Number(params.id))} 특별여행`} />
+      <HomeAdvertisements />
       <HydrationBoundary state={dehydrateState}>
         <AdvertisementInfomation />
       </HydrationBoundary>

--- a/src/app/(non-navbar)/advertisement/[id]/page.tsx
+++ b/src/app/(non-navbar)/advertisement/[id]/page.tsx
@@ -1,0 +1,29 @@
+import DefaultHeader from "@/app/_component/common/layout/DefaultHeader";
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from "@tanstack/react-query";
+import getAdvertisementInfo from "@/api/advertisement/getAdvertisementInfo";
+import AdvertisementInfomation from "./_component/AdvertisementInfomation";
+
+const AdvertisementPage = async ({ params }: { params: { id: string } }) => {
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["advertisement-info", params.id.toString()],
+    queryFn: async () => {
+      return getAdvertisementInfo(Number(params.id));
+    },
+  });
+  const dehydrateState = dehydrate(queryClient);
+  return (
+    <section className="w-full flex flex-col items-center">
+      <DefaultHeader theme="default" text="hi" />
+      <HydrationBoundary state={dehydrateState}>
+        <AdvertisementInfomation />
+      </HydrationBoundary>
+    </section>
+  );
+};
+
+export default AdvertisementPage;

--- a/src/app/_component/home/HomeAdvertisements.tsx
+++ b/src/app/_component/home/HomeAdvertisements.tsx
@@ -89,7 +89,7 @@ const HomeAdvertisements = () => {
           </SwiperSlide>
         ))}
       </Swiper>
-      <div className="mr-3">
+      <div className="[&>*]:mr-3">
         <SwiperBadge slideIndex={slideIndex} slideLength={3} />
       </div>
     </div>

--- a/src/app/_component/home/HomeAdvertisements.tsx
+++ b/src/app/_component/home/HomeAdvertisements.tsx
@@ -82,7 +82,7 @@ const HomeAdvertisements = () => {
                 fill
                 className="rounded-lg"
                 onClick={() => {
-                  router.push("/"); // 추후 200_광고및프로모션구좌 페이지 URL 결정시 수정 예정
+                  router.push(`advertisement/${ads.adId}`);
                 }}
               />
             </div>

--- a/src/app/_component/home/HomeAdvertisements.tsx
+++ b/src/app/_component/home/HomeAdvertisements.tsx
@@ -82,7 +82,7 @@ const HomeAdvertisements = () => {
                 fill
                 className="rounded-lg"
                 onClick={() => {
-                  router.push(`advertisement/${ads.adId}`);
+                  router.push(`/advertisement/${ads.adId}`);
                 }}
               />
             </div>

--- a/src/app/_component/home/HomeAdvertisements.tsx
+++ b/src/app/_component/home/HomeAdvertisements.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import getAdvertisements from "@/api/home/getAdvertisements";
+import { AdvertisementItem } from "@/app/types";
 
 import { Swiper, SwiperSlide } from "swiper/react";
 import SwiperCore from "swiper";
@@ -13,14 +14,13 @@ import "swiper/css";
 import "swiper/css/navigation";
 
 interface Props {
-  adId: number;
-  imageUrl: string;
+  isDetail?: boolean;
 }
 
-const HomeAdvertisements = () => {
+const HomeAdvertisements = ({ isDetail }: Props) => {
   const router = useRouter();
   // 광고구좌 목록 조회 API를 통해 받아온 응답 데이터 관리하기 위한 state 선언
-  const [adsData, setAdsData] = useState<Props[]>([]);
+  const [adsData, setAdsData] = useState<AdvertisementItem[]>([]);
 
   // 광고구좌 데이터 fetch
   useEffect(() => {
@@ -54,7 +54,13 @@ const HomeAdvertisements = () => {
   };
 
   return (
-    <div className="w-[100%] h-[240px] px-6 mb-10 relative">
+    <div
+      className={
+        isDetail
+          ? "w-[100%] h-[240px] mb-10 relative"
+          : "w-[100%] h-[240px] px-6 mb-10 relative"
+      }
+    >
       <Swiper
         onSwiper={(swiper) => {
           swiperRef.current = swiper;
@@ -75,12 +81,12 @@ const HomeAdvertisements = () => {
       >
         {adsData?.map((ads) => (
           <SwiperSlide key={`ad-${ads.adId}`}>
-            <div className="w-[327px] web:w-full h-[240px] relative">
+            <div className="w-full web:w-full h-[240px] relative">
               <Image
                 src={ads.imageUrl}
                 alt="테스트이미지"
                 fill
-                className="rounded-lg"
+                className={!isDetail ? "rounded-lg" : ""}
                 onClick={() => {
                   router.push(`/advertisement/${ads.adId}`);
                 }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,8 @@ import BottomNav from "./_component/common/layout/BottomNav";
 import DefaultHeader from "./_component/common/layout/DefaultHeader";
 import HomeAdvertisements from "./_component/home/HomeAdvertisements";
 import HomeHashtags from "./_component/home/HomeHashtags";
-import HomePackages from "./_component/home/HomePackages";
-import HomeProsAndCons from "./_component/home/HomeProsAndCons";
+// import HomePackages from "./_component/home/HomePackages";
+// import HomeProsAndCons from "./_component/home/HomeProsAndCons";
 import HomeThemePackage from "./_component/home/HomeThemePackage";
 import ContentsContainer from "./_component/common/layout/ContentsContainer";
 
@@ -23,13 +23,13 @@ const Home = async () => {
               <HomeThemePackage />
             </ContentsContainer>
             {/* 찬반토론 */}
-            <ContentsContainer title="찬반 토론 참여">
+            {/* <ContentsContainer title="찬반 토론 참여">
               <HomeProsAndCons />
-            </ContentsContainer>
+            </ContentsContainer> */}
             {/* 초특가 패키지 목록 */}
-            <ContentsContainer title="지금 핫한 초특가 상품">
+            {/* <ContentsContainer title="지금 핫한 초특가 상품">
               <HomePackages />
-            </ContentsContainer>
+            </ContentsContainer> */}
           </div>
         </section>
       </main>

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -201,3 +201,8 @@ export interface PollsFalse {
   A: string[];
   B: string[];
 }
+
+export interface AdvertisementItem {
+  adId: number;
+  imageUrl: string;
+}

--- a/src/hooks/query/useAdvertisementInfoQuery.ts
+++ b/src/hooks/query/useAdvertisementInfoQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import getAdvertisementInfo from "@/api/advertisement/getAdvertisementInfo";
+
+const useAdvertisementInfoQuery = (id: string | string[]) => {
+  return useQuery({
+    queryKey: ["advertisement-info", id],
+    queryFn: async () => {
+      return getAdvertisementInfo(Number(id));
+    },
+  });
+};
+
+export default useAdvertisementInfoQuery;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -259,18 +259,15 @@ const handlers = [
     const advertisements = [
       {
         adId: 0,
-        imageUrl:
-          "https://images.theconversation.com/files/318067/original/file-20200302-18287-i7bt82.jpg",
+        imageUrl: "https://i.postimg.cc/6p92q9KD/japan.png",
       },
       {
         adId: 1,
-        imageUrl:
-          "https://images.theconversation.com/files/318067/original/file-20200302-18287-i7bt82.jpg",
+        imageUrl: "https://i.postimg.cc/zG0LR9X3/taiwan.png",
       },
       {
         adId: 2,
-        imageUrl:
-          "https://images.theconversation.com/files/318067/original/file-20200302-18287-i7bt82.jpg",
+        imageUrl: "https://i.postimg.cc/RV1JvWk7/europe.png",
       },
     ];
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -280,22 +280,91 @@ const handlers = [
     });
   }),
 
-  http.get("/v1/advertisements/{adId}", () => {
+  http.get("/v1/advertisements/:id", () => {
     console.log("광고구좌 조회");
     const advertisementInfo = {
       adId: 0,
-      name: "오사카 특별 기획전",
-      description: "오사카의 13가지 매력속으로!",
-      imageUrls: [
-        "https://images.theconversation.com/files/318067/original/file-20200302-18287-i7bt82.jpg?ixlib=rb-1.1.0&rect=21%2C5%2C3496%2C2747&q=20&auto=format&w=320&fit=clip&dpr=2&usm=12&cs=strip",
-      ],
+      name: "오사카 특별 여행",
       packages: [
         {
           packageId: 0,
-          imageUrl: "",
-          transporation: "",
-          title: "",
-          minPrice: 0,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production188/d1049/eda6e352-4711-4542-bc24-fbf43f612931.jpg",
+          transporation: "비행기",
+          title: "오사카성",
+          minPrice: 270000,
+        },
+        {
+          packageId: 1,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production68/d1303/c8fa75d8-6932-459b-9660-8340f097ebd7.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "배",
+          title: "도톤보리",
+          minPrice: 340000,
+        },
+        {
+          packageId: 2,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production137/d1766/cc50b4a1-2ed1-442f-9892-a9233ff9ef8c.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "도보",
+          title: "유니버설 스튜디오 재팬",
+          minPrice: 400000,
+        },
+        {
+          packageId: 3,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production153/d1748/fdcb8bd4-962b-4892-8e3e-fbaa75211fb4.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "보트",
+          title: "가이유칸 수족관",
+          minPrice: 450000,
+        },
+        {
+          packageId: 4,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production71/d1615/f53f26ff-02e7-4f3f-bb71-4aa8513d4175.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "자전거",
+          title: "덴포잔 대관람차",
+          minPrice: 500000,
+        },
+        {
+          packageId: 5,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production130/d1315/67f50c0e-b127-465f-8bbf-c950d676c968.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "킥보드",
+          title: "야요이문화 현립박물관",
+          minPrice: 550000,
+        },
+        {
+          packageId: 6,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production10/d521/a95d7c84-b083-45dd-8530-8a8d93ad578e.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "자동차",
+          title: "시텐노지",
+          minPrice: 600000,
+        },
+        {
+          packageId: 7,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production0/d434/a646fde9-8b37-43b9-af33-fca9b5754ad2.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "헬리콥터",
+          title: "우메다 스카이 빌딩",
+          minPrice: 650000,
+        },
+        {
+          packageId: 8,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production121/d1659/e49284fe-ddda-44da-b407-dd504da048bc.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "도보",
+          title: "사카이 칼 박물관",
+          minPrice: 700000,
+        },
+        {
+          packageId: 9,
+          imageUrl:
+            "https://a.cdn-hotels.com/gdcs/production176/d1897/982b8faf-6bb4-4d2d-b156-e6ac40fcb4f0.jpg?impolicy=fcrop&w=1600&h=1066&q=medium",
+          transporation: "전세기",
+          title: "오사카 스모 대회",
+          minPrice: 800000,
         },
       ],
     };

--- a/src/utils/formatLongText.ts
+++ b/src/utils/formatLongText.ts
@@ -1,0 +1,19 @@
+/*
+  특정 길이 넘어가는 텍스트 말줄임표 가공하기
+  parameters
+  - originalText: string  (원본 텍스트)
+  - textLimit: number     (제한할 길이)
+  
+  전달받은 문자열이 제한하고자 하는 길이를 초과한다면, 해당 길이만큼으로 문자열을 자르고 뒤에 ... 을 붙이는 식으로 가공해 반환합니다.
+  textLimit의 길이 이하인 경우, 전달받았던 문자열을 그대로 반환합니다.
+*/
+
+const formatLongText = (originalText: string, textLimit: number) => {
+  if (originalText.length > textLimit) {
+    const trimmedText = originalText.substring(0, textLimit);
+    return trimmedText.concat(" ...");
+  }
+  return originalText;
+};
+
+export default formatLongText;

--- a/src/utils/getAdsHeaderText.ts
+++ b/src/utils/getAdsHeaderText.ts
@@ -1,0 +1,19 @@
+/*
+  광고구좌 페이지 내 헤더 텍스트 반환
+  전달받은 광고의 인덱스(adId)를 기준으로 특정 문자열을 반환합니다.
+*/
+
+const getAdsHeaderText = (index: number) => {
+  switch (index) {
+    case 1:
+      return "오사카";
+    case 2:
+      return "대만";
+    case 3:
+      return "유럽";
+    default:
+      return "";
+  }
+};
+
+export default getAdsHeaderText;


### PR DESCRIPTION
## 구현 내용
200_광고 및 프로모션 구좌 페이지 퍼블리싱 진행하였습니다!
<img width="409" alt="스크린샷 2024-01-22 오후 4 54 49" src="https://github.com/yanolja-finalproject/LETS_FE/assets/62874043/b5a77421-0521-45a8-a38f-12637bca2ad1">

- 메인 페이지 상단의 광고구좌 슬라이드를 선택해 해당 광고 페이지로 이동합니다.
  - /advertisement/{id} 의 URL 구조로 이동합니다.
 
- 해당 페이지에서는 광고구좌 목록 조회(v1/advertisements/), 광고구좌 조회(v1/advertisements/{id}) 두 API를 호출합니다.
  - 광고구좌 목록 조회(v1/advertisements/)의 경우는 광고구좌 페이지 상단에서의 슬라이드 노출을 위해서,
  - 광고구좌 조회(v1/advertisements/{id})는 광고구좌 내 패키지상품 나열을 위해 사용합니다.

## 기타
- 200_광고 및 프로모션 페이지 내에서는 사용하지 않았지만, 텍스트 길이가 긴 문자열에 대해 말줄임표 (...) 를 붙이는 util 컴포넌트 (formatLongText.ts)를 추가했습니다!
  - utils 폴더 안에 위치하고 있습니다.
  - 인자로는 원본 문자열과 제한할 숫자 길이를 받습니다.
  - 전달받은 문자열이 제한할 숫자 길이를 초과하면 문자열을 해당 길이만큼 자르고, "..." 을 뒤에 덧붙여 반환합니다.
  - 제한할 숫자 길이 이하인 경우는 전달받았던 문자열을 그대로 반환합니다!
  - 패키지 상품 제목이나 설명이 너무 길어서 간추려야 할 경우 사용하실 수 있을것같은데요, 혹시 사용되는 컴포넌트가 없다면 추후 PR에서 삭제하겠습니다... 

- next.config.js 내 image 도메인 부분 구조 수정했습니다!
  - 기존 테스트용 URL 주소 포함되어 있던 부분 수정했습니다.
  
- handler.ts 파일 수정되었습니다.
  - /advertisements/{id} API 부분 MSW 연동을 위한 테스트 코드 핸들러에 추가했습니다!
  
- 메인 페이지 내 찬반토론 / 초특가 패키지 부분 임시 주석처리했습니다.
  - 해당 컴포넌트 내에서 setState부분 관련해 오류나는 부분이 있어서 로컬에서 작업하실 때 불편하시지 않게끔 임시로 가려두었습니다!
  - 빠르게 고치겠습니다ㅠㅠ 

## 이슈번호
X
