### PR TITLE
Refactor: 이미지 비율 처리 / 테마페이지 로딩스피너 적용

### DIFF
--- a/src/app/(non-navbar)/advertisement/[id]/_component/AdvertisementDetail.tsx
+++ b/src/app/(non-navbar)/advertisement/[id]/_component/AdvertisementDetail.tsx
@@ -54,10 +54,10 @@ const AdvertisementDetail = () => {
             <img
               src={singlePackage.imageUrl}
               alt="packageImg"
-              className="w-[155px] h-[180px] web:w-full mb-2 rounded-lg"
+              className="w-[100%] h-[180px] web:w-full mb-2 rounded-lg"
             />
             <div className="flex flex-col gap-[14px]">
-              <p className="w-[148px] h-[30px] web:w-full text-black-6 text-xs font-normal overflow-hidden">
+              <p className="w-[100%] h-[30px] web:w-full text-black-6 text-xs font-normal overflow-hidden">
                 {singlePackage.title}
               </p>
               <p className="text-black text-base font-bold">

--- a/src/app/(non-navbar)/theme/[id]/_component/ThemeDetail.tsx
+++ b/src/app/(non-navbar)/theme/[id]/_component/ThemeDetail.tsx
@@ -4,6 +4,7 @@ import useThemeQuery from "@/hooks/query/useThemeQuery";
 import { ThemeItem, ThemePackage } from "@/app/types";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import Spinner from "@/app/_component/common/layout/Spinner";
 
 const ThemeDetail = () => {
   const params = useParams();
@@ -12,7 +13,7 @@ const ThemeDetail = () => {
   // 테마 대표 이미지와 소개 텍스트를 한번만 사용하기 위한 대표 테마 패키지를 설정하기 위한 state
   const [themeTitleData, setThemeTitleData] = useState<ThemeItem>();
   // /v1/themes/{themeId} 테마 패키지 조회 API 호출
-  const { data } = useThemeQuery(params.id, "departure_date", 1, 10);
+  const { data, isLoading } = useThemeQuery(params.id, "departure_date", 1, 10);
 
   useEffect(() => {
     if (data) {
@@ -23,6 +24,10 @@ const ThemeDetail = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
+  if (isLoading) {
+    return <Spinner />;
+  }
+
   return (
     <div className="w-full">
       <div>
@@ -30,7 +35,7 @@ const ThemeDetail = () => {
         <img
           src={themeTitleData?.imageUrl}
           alt="theme"
-          className="w-[375px] web:w-full h-[320px] object-cover"
+          className="w-full h-[320px] object-cover"
         />
         {/* 테마 설명 텍스트 영역 */}
         <div className="flex flex-col pt-[32px] pb-[40px] gap-4 items-center">
@@ -43,30 +48,31 @@ const ThemeDetail = () => {
         </div>
       </div>
       <div className="px-6 grid grid-cols-2 grid-rows-2 gap-[17px]">
-        {themeData?.map((theme) => (
-          <div key={`themePackage-${theme.themeId}`}>
+        {themeData?.map((theme, index) => (
+          <div key={`themePackage-${index}`}>
             {/* 테마 내 패키지에서 이미지, 가격, 제목 정보 나열 */}
             {theme.packages?.map((singlePackage: ThemePackage) => (
-              <div>
-                <div
-                  className="w-full h-auto flex-col relative"
-                  onClick={() =>
-                    router.push(`/items/${singlePackage.packageId}`)
-                  } // 클릭시 상세 페이지 연결
-                >
-                  <img
-                    src={singlePackage.imageUrl}
-                    alt="packageImg"
-                    className="object-cover w-full h-[180px] web:w-full mb-2 rounded-lg"
-                  />
-                  <div className="flex flex-col gap-[14px]">
-                    <p className="w-[148px] h-[30px] web:w-full text-black-6 text-xs font-normal overflow-hidden">
-                      {singlePackage.title}
-                    </p>
-                    <p className="text-black text-base font-bold">
-                      {`${theme.minPrice.toLocaleString()}원~`}
-                    </p>
-                  </div>
+              <div
+                key={singlePackage.packageId}
+                className="w-full h-auto flex-col relative"
+                onClick={() => router.push(`/items/${singlePackage.packageId}`)} // 클릭시 상세 페이지 연결
+              >
+                <img
+                  src={
+                    singlePackage.imageUrl
+                      ? singlePackage.imageUrl
+                      : "/assets/imageLoadError.png"
+                  }
+                  alt="packageImg"
+                  className="object-cover w-full h-[180px] web:w-full mb-2 rounded-lg"
+                />
+                <div className="flex flex-col gap-[14px]">
+                  <p className="w-[100%] h-[30px] web:w-full text-black-6 text-xs font-normal overflow-hidden">
+                    {singlePackage.title}
+                  </p>
+                  <p className="text-black text-base font-bold">
+                    {`${theme.minPrice.toLocaleString()}원~`}
+                  </p>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## 구현 내용
- 광고구좌 페이지 내 이미지 픽셀 설정함으로 인해 모바일과 웹뷰 사이 ( 376 ~ 499px )에서 레이아웃이 깨지는 문제가 있어 width값을 100%로 주는 식으로 수정했습니다.
- 테마 페이지 로딩 스피너 적용했습니다.

## 기타
X

## 이슈번호
X